### PR TITLE
AHN tiles in init

### DIFF
--- a/packages/core/src/bag3d/core/assets/ahn/__init__.py
+++ b/packages/core/src/bag3d/core/assets/ahn/__init__.py
@@ -1,0 +1,77 @@
+from typing import Dict, Optional, Tuple
+
+import requests
+
+
+def download_ahn_index(
+    with_geom: bool = False,
+) -> Optional[Dict[str, Optional[Dict[str, Optional[str]]]]]:
+    """Downloads the AHN 3/4/5 tile index.
+    Args:
+        ahn_version: The AHN version, either 3 or 4 or 5.
+        with_geom: If False, request only the AHN tile ids. Else also request the
+            tile boundaries as geojson.
+    Returns:
+        A dict of {tile id: link to laz}. If not ``with_geom``, then value of the link is None.
+    """
+
+    service_url = (
+        "https://api.ellipsis-drive.com/v3/ogc/wfs/a9d410ad-a2f6-404c-948a-fdf6b43e77a6"
+    )
+    print(f"Downloading the AHN tile boundaries from {service_url}")
+    params_features = {
+        "request": "GetFeature",
+        "service": "WFS",
+        "preferCoordinatesForWfsT11": "true",
+        "srsname": "EPSG:28992",
+        "version": "1.1.0",
+        "requestedEpsg": "28992",
+        "outputFormat": "application/json",
+        "CountDefault": "2000",
+        "typeName": "layerId_14b12666-cfbb-4362-905a-8832afe5ffa8",
+    }
+
+    features = {}
+    # TODO: include the tile geometry, and maybe use the download links from here
+
+    response = requests.get(url=service_url + "/query", params=params_features)
+    if response.status_code == 200:
+        r_json = response.json()
+    else:  # pragma: no cover
+        response.raise_for_status()
+        return
+    returned_features = r_json.get("features")
+    if returned_features is None or len(returned_features) == 0:
+        return features
+    else:
+        if with_geom:
+            for f in r_json["features"]:
+                features[f["properties"]["AHN"].lower()] = {
+                    "AHN3_LAZ": f["properties"]["AHN3 puntenwolk"],
+                    "AHN4_LAZ": f["properties"]["AHN4 puntenwolk"],
+                    "AHN5_LAZ": f["properties"]["AHN5 puntenwolk"],
+                    "geometry": f["geometry"],
+                }
+        else:
+            for f in r_json["features"]:
+                features[f["properties"]["AHN"].lower()] = None
+
+    return features
+
+
+def tile_index_origin() -> Tuple[float, float, float, float]:  # pragma: no cover
+    """Computes the BBOX of the AHN tile index."""
+    tindex = download_ahn_index(True)
+    minx, miny = tindex["01cz1"]["geometry"]["coordinates"][0][0]
+    maxx, maxy = minx, miny
+    for feature in tindex.values():
+        exterior = feature["geometry"]["coordinates"][0]
+        for x, y in exterior:
+            minx = x if x < minx else minx
+            miny = y if y < miny else miny
+            maxx = x if x > maxx else maxx
+            maxy = y if y > maxy else maxy
+    return minx, miny, maxx, maxy
+
+
+TILES = download_ahn_index(with_geom=True)

--- a/packages/core/src/bag3d/core/assets/ahn/core.py
+++ b/packages/core/src/bag3d/core/assets/ahn/core.py
@@ -1,15 +1,15 @@
 from pathlib import Path
-from typing import Tuple, Dict, Optional
+from typing import Tuple
 from math import ceil
 
-import requests
 from dagster import StaticPartitionsDefinition
+
+from bag3d.core.assets.ahn import TILES
 
 
 class PartitionDefinitionAHN(StaticPartitionsDefinition):
     def __init__(self):
-        tile_ids = download_ahn_index(with_geom=False)
-        super().__init__(partition_keys=sorted(list(tile_ids)))
+        super().__init__(partition_keys=sorted(list(TILES)))
 
 
 def format_laz_log(fpath: Path, msg: str) -> str:
@@ -32,78 +32,6 @@ def ahn_laz_dir(root_dir: Path, ahn_version: int) -> Path:
     """Create a directory path where to store the AHN LAZ files for the given AHN
     version."""
     return ahn_dir(root_dir, ahn_version) / "as_downloaded" / "LAZ"
-
-
-def download_ahn_index(
-    with_geom: bool = False,
-) -> Optional[Dict[str, Optional[Dict[str, Optional[str]]]]]:
-    """Downloads the AHN 3/4/5 tile index.
-    Args:
-        ahn_version: The AHN version, either 3 or 4 or 5.
-        with_geom: If False, request only the AHN tile ids. Else also request the
-            tile boundaries as geojson.
-    Returns:
-        A dict of {tile id: link to laz}. If not ``with_geom``, then value of the link is None.
-    """
-
-    service_url = (
-        "https://api.ellipsis-drive.com/v3/ogc/wfs/a9d410ad-a2f6-404c-948a-fdf6b43e77a6"
-    )
-    params_features = {
-        "request": "GetFeature",
-        "service": "WFS",
-        "preferCoordinatesForWfsT11": "true",
-        "srsname": "EPSG:28992",
-        "version": "1.1.0",
-        "requestedEpsg": "28992",
-        "outputFormat": "application/json",
-        "CountDefault": "2000",
-        "typeName": "layerId_14b12666-cfbb-4362-905a-8832afe5ffa8",
-    }
-    print(f"Downloading the AHN tile boundaries from {service_url}")
-
-    features = {}
-    # TODO: include the tile geometry, and maybe use the download links from here
-
-    response = requests.get(url=service_url + "/query", params=params_features)
-    if response.status_code == 200:
-        r_json = response.json()
-    else:  # pragma: no cover
-        response.raise_for_status()
-        return
-    returned_features = r_json.get("features")
-    if returned_features is None or len(returned_features) == 0:
-        return features
-    else:
-        if with_geom:
-            for f in r_json["features"]:
-                features[f["properties"]["AHN"].lower()] = {
-                    "AHN3_LAZ": f["properties"]["AHN3 puntenwolk"],
-                    "AHN4_LAZ": f["properties"]["AHN4 puntenwolk"],
-                    "AHN5_LAZ": f["properties"]["AHN5 puntenwolk"],
-                    "geometry": f["geometry"],
-                }
-        else:
-            for f in r_json["features"]:
-                features[f["properties"]["AHN"].lower()] = None
-
-    return features
-
-
-def tile_index_origin() -> Tuple[float, float, float, float]:  # pragma: no cover
-    """Computes the BBOX of the AHN tile index."""
-    tindex = download_ahn_index(True)
-    minx, miny = tindex["01cz1"]["geometry"]["coordinates"][0][0]
-    maxx, maxy = minx, miny
-    for feature in tindex.values():
-        exterior = feature["geometry"]["coordinates"][0]
-        for x, y in exterior:
-            minx = x if x < minx else minx
-            miny = y if y < miny else miny
-            maxx = x if x > maxx else maxx
-            maxy = y if y > maxy else maxy
-    # 13000 306250 279000 616250
-    return minx, miny, maxx, maxy
 
 
 def generate_grid(bbox: Tuple[float, float, float, float], cellsize: int):

--- a/packages/core/src/bag3d/core/assets/ahn/download.py
+++ b/packages/core/src/bag3d/core/assets/ahn/download.py
@@ -10,9 +10,10 @@ from bag3d.core.assets.ahn.core import (
     PartitionDefinitionAHN,
     format_laz_log,
     ahn_filename,
-    download_ahn_index,
     ahn_laz_dir,
 )
+
+from bag3d.core.assets.ahn import TILES
 
 logger = get_dagster_logger("ahn.download")
 
@@ -131,7 +132,7 @@ def md5_pdok_ahn4(context):
 @asset
 def tile_index_pdok(context):
     """The AHN tile index, including the tile geometry and the file donwload links."""
-    return download_ahn_index(with_geom=True)
+    return TILES
 
 
 @asset(

--- a/packages/core/tests/test_assets_ahn.py
+++ b/packages/core/tests/test_assets_ahn.py
@@ -1,7 +1,9 @@
 import pytest
+
+from bag3d.core.assets.ahn import download_ahn_index, tile_index_origin
+
 from bag3d.core.assets.ahn.core import (
     ahn_laz_dir,
-    download_ahn_index,
     generate_grid,
 )
 from bag3d.core.assets.ahn.download import (
@@ -16,6 +18,14 @@ from bag3d.core.assets.ahn.download import (
 from bag3d.core.assets.ahn.metadata import metadata_table_ahn3, metadata_table_ahn4
 from bag3d.common.types import PostgresTableIdentifier
 from bag3d.common.utils.database import table_exists
+
+
+def test_tile_index_origin():
+    minx, miny, maxx, maxy = tile_index_origin()
+    assert minx == pytest.approx(9999.99998)
+    assert miny == pytest.approx(306250.00034)
+    assert maxx == pytest.approx(280000.00023)
+    assert maxy == pytest.approx(625000.00053)
 
 
 def test_download_ahn_index():


### PR DESCRIPTION
My suggestion for initialising the AHN tile list only when the core package is initialized. This would have the following effect when dagster is running; the tile list will be use in the PartitionDefinition instead of the function ("USING TILES"), and the list is being updated less times. 

![image](https://github.com/user-attachments/assets/696cf8ae-3434-40f5-8c84-2fa54f154c11)

Not sure if this is what you had in mind but we can try it. 