### PR TITLE
Add the rest of the pre-ahn assets to the tile index jobs

### DIFF
--- a/packages/core/src/bag3d/core/code_location.py
+++ b/packages/core/src/bag3d/core/code_location.py
@@ -10,7 +10,7 @@ from bag3d.core.asset_groups import (
 )
 from bag3d.core.jobs import (
     job_source_input,
-    job_tile_index,
+    job_ahn_tile_index,
     job_ahn3,
     job_ahn4,
     job_ahn5,
@@ -33,7 +33,7 @@ all_assets = [
 
 all_jobs = [
     job_source_input,
-    job_tile_index,
+    job_ahn_tile_index,
     job_ahn3,
     job_ahn4,
     job_ahn5,

--- a/packages/core/src/bag3d/core/jobs.py
+++ b/packages/core/src/bag3d/core/jobs.py
@@ -4,14 +4,14 @@ from dagster import define_asset_job, AssetSelection
 job_ahn_tile_index = define_asset_job(
     name="ahn_tile_index",
     description="Get the tile index (bladwijzer), md5 hashes of the LAZ files and "
-                "create the tables for storing the metadata for AHN 3, 4 and 5, so that "
-                "the AHN jobs can be run.",
+    "create the tables for storing the metadata for AHN 3, 4 and 5, so that "
+    "the AHN jobs can be run.",
     selection=AssetSelection.assets(["ahn", "tile_index_pdok"])
     | AssetSelection.assets(["ahn", "md5_pdok_ahn3"])
     | AssetSelection.assets(["ahn", "md5_pdok_ahn4"])
     | AssetSelection.assets(["ahn", "metadata_table_ahn3"])
     | AssetSelection.assets(["ahn", "metadata_table_ahn4"])
-    | AssetSelection.assets(["ahn", "metadata_table_ahn5"])
+    | AssetSelection.assets(["ahn", "metadata_table_ahn5"]),
 )
 
 # WARNING!!! multi_assets don't have key_prefix, https://github.com/dagster-io/dagster/issues/9344
@@ -28,7 +28,7 @@ job_ahn4 = define_asset_job(
     name="ahn4",
     description="Make sure that the available AHN 4 LAZ files are present on disk, "
     "and their metadata is recorded.",
-    selection= AssetSelection.assets(["ahn", "laz_files_ahn4"])
+    selection=AssetSelection.assets(["ahn", "laz_files_ahn4"])
     | AssetSelection.assets(["ahn", "metadata_ahn4"])
     | AssetSelection.assets(["ahn", "lasindex_ahn4"]),
 )
@@ -37,7 +37,7 @@ job_ahn5 = define_asset_job(
     name="ahn5",
     description="Make sure that the available AHN 5 LAZ files are present on disk, "
     "and their metadata is recorded.",
-    selection= AssetSelection.assets(["ahn", "laz_files_ahn5"])
+    selection=AssetSelection.assets(["ahn", "laz_files_ahn5"])
     | AssetSelection.assets(["ahn", "metadata_ahn5"])
     | AssetSelection.assets(["ahn", "lasindex_ahn5"]),
 )

--- a/packages/core/src/bag3d/core/jobs.py
+++ b/packages/core/src/bag3d/core/jobs.py
@@ -1,10 +1,17 @@
 from dagster import define_asset_job, AssetSelection
 
 
-job_tile_index = define_asset_job(
-    name="tile_index",
-    description="Get the tile_index for AHN 3, 4 and 5.",
-    selection=AssetSelection.assets(["ahn", "tile_index_pdok"]),
+job_ahn_tile_index = define_asset_job(
+    name="ahn_tile_index",
+    description="Get the tile index (bladwijzer), md5 hashes of the LAZ files and "
+                "create the tables for storing the metadata for AHN 3, 4 and 5, so that "
+                "the AHN jobs can be run.",
+    selection=AssetSelection.assets(["ahn", "tile_index_pdok"])
+    | AssetSelection.assets(["ahn", "md5_pdok_ahn3"])
+    | AssetSelection.assets(["ahn", "md5_pdok_ahn4"])
+    | AssetSelection.assets(["ahn", "metadata_table_ahn3"])
+    | AssetSelection.assets(["ahn", "metadata_table_ahn4"])
+    | AssetSelection.assets(["ahn", "metadata_table_ahn5"])
 )
 
 # WARNING!!! multi_assets don't have key_prefix, https://github.com/dagster-io/dagster/issues/9344
@@ -21,9 +28,7 @@ job_ahn4 = define_asset_job(
     name="ahn4",
     description="Make sure that the available AHN 4 LAZ files are present on disk, "
     "and their metadata is recorded.",
-    selection=AssetSelection.assets(["ahn", "md5_pdok_ahn4"])
-    | AssetSelection.assets(["ahn", "metadata_table_ahn4"])
-    | AssetSelection.assets(["ahn", "laz_files_ahn4"])
+    selection= AssetSelection.assets(["ahn", "laz_files_ahn4"])
     | AssetSelection.assets(["ahn", "metadata_ahn4"])
     | AssetSelection.assets(["ahn", "lasindex_ahn4"]),
 )
@@ -32,8 +37,7 @@ job_ahn5 = define_asset_job(
     name="ahn5",
     description="Make sure that the available AHN 5 LAZ files are present on disk, "
     "and their metadata is recorded.",
-    selection=AssetSelection.assets(["ahn", "metadata_table_ahn5"])
-    | AssetSelection.assets(["ahn", "laz_files_ahn5"])
+    selection= AssetSelection.assets(["ahn", "laz_files_ahn5"])
     | AssetSelection.assets(["ahn", "metadata_ahn5"])
     | AssetSelection.assets(["ahn", "lasindex_ahn5"]),
 )


### PR DESCRIPTION
Adds the md5 assets and the ahn metadata creation assets to the ahn job, because all of it is required for running the ahn jobs.