### PR TITLE
59 resources should initialize without values

### DIFF
--- a/packages/common/src/bag3d/common/resources/__init__.py
+++ b/packages/common/src/bag3d/common/resources/__init__.py
@@ -132,7 +132,7 @@ resource_defs_by_env_name = {
     "local": RESOURCES_LOCAL,
     "test": RESOURCES_PYTEST,
     "default": RESOURCES_DEFAULT,
-    }
+}
 env_name = os.getenv("DAGSTER_ENVIRONMENT", "default").lower()
 if env_name not in resource_defs_by_env_name.keys():
     logger.warning(f"Invalid environment: {env_name}, setting to default")

--- a/packages/common/src/bag3d/common/resources/database.py
+++ b/packages/common/src/bag3d/common/resources/database.py
@@ -12,29 +12,29 @@ class DatabaseResource(ConfigurableResource):
     Database connection.
     """
 
-    host: str
-    user: str
-    password: str
-    dbname: str
-    port: str
-    other_params: Permissive()
+    host: Optional[str] = None
+    user: Optional[str] = None
+    password: Optional[str] = None
+    dbname: Optional[str] = None
+    port: Optional[str] = None
+    other_params: Optional[Permissive()] = None
 
     def __init__(
         self,
-        host: str,
-        user: str,
-        password: str,
-        dbname: str,
-        port: str,
+        host: Optional[str] = None,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        dbname: Optional[str] = None,
+        port: Optional[str] = None,
         other_params: Optional[Permissive()] = None,
     ):
         super().__init__(
-            host=host,
-            user=user,
-            password=password,
-            dbname=dbname,
-            port=port,
-            other_params=other_params or {},
+            host=host or "data-postgresql",
+            user=user or "baseregisters_test_user",
+            password=password or "baseregisters_test_pswd",
+            dbname=dbname or "baseregisters_test",
+            port=port or "5432",
+            other_params=other_params or {"sslmode": "allow"},
         )
         conn = DatabaseConnection(
             user=self.user,

--- a/packages/common/src/bag3d/common/resources/executables.py
+++ b/packages/common/src/bag3d/common/resources/executables.py
@@ -334,25 +334,19 @@ class PDALResource(ConfigurableResource):
         pdal_resource.app
     """
 
-    exe_pdal: str
-    docker_cfg: DockerConfig
-
-    def __init__(
-        self,
-        exe_pdal: Optional[str] = None,
-        docker_cfg: Optional[DockerConfig] = None,
-    ):
-        super().__init__(
-            exe_pdal=exe_pdal or "pdal",
-            docker_cfg=docker_cfg
-            or DockerConfig(image=DOCKER_PDAL_IMAGE, mount_point="/tmp"),
-        )
+    exe_pdal: Optional[str] = None
+    docker_cfg: Optional[DockerConfig] = None
 
     @property
     def exes(self) -> Dict[str, str]:
-        return {
-            "pdal": self.exe_pdal,
-        }
+        if self.docker_cfg is None:
+            return {
+                "pdal": self.exe_pdal,
+            }
+        else:
+            return {
+                "pdal": "pdal",
+            }
 
     @property
     def with_docker(self) -> bool:
@@ -384,8 +378,8 @@ class LASToolsResource(ConfigurableResource):
         lastools_resource.app
     """
 
-    exe_lasindex: str
-    exe_las2las: str
+    exe_lasindex: Optional[str] = None
+    exe_las2las: Optional[str] = None
 
     @property
     def exes(self) -> Dict[str, str]:
@@ -416,8 +410,8 @@ class TylerResource(ConfigurableResource):
         tyler = tyler_resource.app
     """
 
-    exe_tyler: str
-    exe_tyler_db: str
+    exe_tyler: Optional[str] = None
+    exe_tyler_db: Optional[str] = None
 
     @property
     def exes(self) -> Dict[str, str]:
@@ -448,8 +442,8 @@ class RooferResource(ConfigurableResource):
         roofer = roofer_resource.app
     """
 
-    exe_crop: str
-    exe_roofer: str
+    exe_crop: Optional[str] = None
+    exe_roofer: Optional[str] = None
 
     @property
     def exes(self) -> Dict[str, str]:
@@ -484,8 +478,8 @@ class GeoflowResource(ConfigurableResource):
         geoflow = geoflow_resource.app
     """
 
-    exe_geoflow: str
-    flowchart: str
+    exe_geoflow: Optional[str] = None
+    flowchart: Optional[str] = None
 
     @property
     def exes(self) -> Dict[str, str]:

--- a/packages/common/src/bag3d/common/resources/files.py
+++ b/packages/common/src/bag3d/common/resources/files.py
@@ -102,9 +102,9 @@ class FileStoreResource(ConfigurableResource):
     TODO: make the directory functions in .core (bag3d_export_dir etc) members of this
     """
 
-    data_dir: str
-    docker_volume_id: str
-    dir_id: str
+    data_dir: Optional[str] = None
+    docker_volume_id: Optional[str] = None
+    dir_id: Optional[str] = None
 
     def __init__(
         self,
@@ -113,20 +113,20 @@ class FileStoreResource(ConfigurableResource):
         dir_id: Optional[str] = None,
     ):
         super().__init__(
-            data_dir=str(data_dir) if data_dir else "",
-            docker_volume_id=docker_volume_id or "",
-            dir_id=dir_id or "",
+            data_dir=str(data_dir) if data_dir else None,
+            docker_volume_id=docker_volume_id,
+            dir_id=dir_id,
         )
 
     @property
     def file_store(self) -> FileStore:
-        if self.data_dir != "" and self.dir_id != "":
+        if self.data_dir and self.dir_id:
             return FileStore(data_dir=self.data_dir, dir_id=self.dir_id)
-        elif self.data_dir != "":
+        elif self.data_dir:
             return FileStore(data_dir=self.data_dir)
-        elif self.docker_volume_id != "":
+        elif self.docker_volume_id:
             return FileStore(docker_volume_id=self.docker_volume_id)
-        elif self.dir_id != "":
+        elif self.dir_id:
             return FileStore(dir_id=self.dir_id)
         else:
             return FileStore()

--- a/packages/common/src/bag3d/common/resources/version.py
+++ b/packages/common/src/bag3d/common/resources/version.py
@@ -10,7 +10,7 @@ class VersionResource(ConfigurableResource):
     A resource for setting up the version release.
     """
 
-    version: str
+    version: Optional[str] = None
 
     def __init__(
         self,


### PR DESCRIPTION
- The new resources can  be initialized without values.
- Database and version have default values the rest are null
- There is a new env variable for setting the environment. If the variable is not set, then the environment is set to "default"