### PR TITLE
use ahn5 tiles in as_downloaded

### DIFF
--- a/packages/core/src/bag3d/core/assets/reconstruction/reconstruction.py
+++ b/packages/core/src/bag3d/core/assets/reconstruction/reconstruction.py
@@ -285,7 +285,9 @@ def create_roofer_config(
         footprint_file=f"PG:{context.resources.db_connection.connect.dsn} tables={tile_view}",
         ahn3_files=laz_files_ahn3,
         ahn4_files=laz_files_ahn4,
-        ahn5_files=laz_files_ahn5,
+        ahn5_files=ahn_dir(
+            context.resources.file_store.file_store.data_dir, ahn_version=5
+        ).joinpath("as_downloaded/LAZ"),
         output_path=output_dir,
     )
     path_toml = output_dir / "roofer.toml"


### PR DESCRIPTION
Use the AHN5 as_downloaded LAZ files directly in reconstruction, instead of the 200m tiles.