### PR TITLE
Fix typo's in BAG queries

### DIFF
--- a/packages/core/src/bag3d/core/sqlfiles/bag_nummeraanduidingactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bag_nummeraanduidingactueelbestaand.sql
@@ -31,6 +31,6 @@ WHERE (tijdstipinactieflv > ${reference_date} OR tijdstipinactieflv ISNULL)
        (tijdstipeindregistratielv > ${reference_date} OR
         tijdstipeindregistratielv ISNULL))
   AND (begingeldigheid <= ${reference_date} AND
-       (eidgeldigheid = begingelidgheid OR eidgeldigheid > ${reference_date} OR
+       (eindgeldigheid = begingelidgheid OR eindgeldigheid > ${reference_date} OR
         eindgeldigheid ISNULL))
   AND status <> 'Naamgeving ingetrokken';

--- a/packages/core/src/bag3d/core/sqlfiles/bag_nummeraanduidingactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bag_nummeraanduidingactueelbestaand.sql
@@ -31,6 +31,6 @@ WHERE (tijdstipinactieflv > ${reference_date} OR tijdstipinactieflv ISNULL)
        (tijdstipeindregistratielv > ${reference_date} OR
         tijdstipeindregistratielv ISNULL))
   AND (begingeldigheid <= ${reference_date} AND
-       (eindgeldigheid = begingelidgheid OR eindgeldigheid > ${reference_date} OR
+       (eindgeldigheid = begingeldigheid OR eindgeldigheid > ${reference_date} OR
         eindgeldigheid ISNULL))
   AND status <> 'Naamgeving ingetrokken';

--- a/packages/core/src/bag3d/core/sqlfiles/bag_openbareruimteactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bag_openbareruimteactueelbestaand.sql
@@ -28,6 +28,6 @@ WHERE (tijdstipinactieflv > ${reference_date} OR tijdstipinactieflv ISNULL)
        (tijdstipeindregistratielv > ${reference_date} OR
         tijdstipeindregistratielv ISNULL))
   AND (begingeldigheid <= ${reference_date} AND
-       (eidgeldigheid = begingelidgheid OR eidgeldigheid > ${reference_date} OR
+       (eindgeldigheid = begingelidgheid OR eindgeldigheid > ${reference_date} OR
         eindgeldigheid ISNULL))
   AND status <> 'Naamgeving ingetrokken';

--- a/packages/core/src/bag3d/core/sqlfiles/bag_openbareruimteactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bag_openbareruimteactueelbestaand.sql
@@ -28,6 +28,6 @@ WHERE (tijdstipinactieflv > ${reference_date} OR tijdstipinactieflv ISNULL)
        (tijdstipeindregistratielv > ${reference_date} OR
         tijdstipeindregistratielv ISNULL))
   AND (begingeldigheid <= ${reference_date} AND
-       (eindgeldigheid = begingelidgheid OR eindgeldigheid > ${reference_date} OR
+       (eindgeldigheid = begingeldigheid OR eindgeldigheid > ${reference_date} OR
         eindgeldigheid ISNULL))
   AND status <> 'Naamgeving ingetrokken';

--- a/packages/core/src/bag3d/core/sqlfiles/bag_pandactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bag_pandactueelbestaand.sql
@@ -28,8 +28,8 @@ WITH repair AS (SELECT ogc_fid                                                AS
                        (tijdstipeindregistratielv > ${reference_date} OR
                         tijdstipeindregistratielv ISNULL))
                   AND (begingeldigheid <= ${reference_date} AND
-                       (eidgeldigheid = begingelidgheid OR
-                        eidgeldigheid > ${reference_date} OR eindgeldigheid ISNULL))
+                       (eindgeldigheid = begingelidgheid OR
+                        eindgeldigheid > ${reference_date} OR eindgeldigheid ISNULL))
                   AND (status <> 'Niet gerealiseerd pand' AND
                        status <> 'Pand gesloopt' AND
                        status <> 'Bouwvergunning verleend'))

--- a/packages/core/src/bag3d/core/sqlfiles/bag_pandactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bag_pandactueelbestaand.sql
@@ -28,7 +28,7 @@ WITH repair AS (SELECT ogc_fid                                                AS
                        (tijdstipeindregistratielv > ${reference_date} OR
                         tijdstipeindregistratielv ISNULL))
                   AND (begingeldigheid <= ${reference_date} AND
-                       (eindgeldigheid = begingelidgheid OR
+                       (eindgeldigheid = begingeldigheid OR
                         eindgeldigheid > ${reference_date} OR eindgeldigheid ISNULL))
                   AND (status <> 'Niet gerealiseerd pand' AND
                        status <> 'Pand gesloopt' AND

--- a/packages/core/src/bag3d/core/sqlfiles/bag_verblijfsobjectactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bag_verblijfsobjectactueelbestaand.sql
@@ -30,7 +30,7 @@ WHERE (tijdstipinactieflv > ${reference_date} OR tijdstipinactieflv ISNULL)
        (tijdstipeindregistratielv > ${reference_date} OR
         tijdstipeindregistratielv ISNULL))
   AND (begingeldigheid <= ${reference_date} AND
-       (eidgeldigheid = begingelidgheid OR eidgeldigheid > ${reference_date} OR
+       (eindgeldigheid = begingelidgheid OR eindgeldigheid > ${reference_date} OR
         eindgeldigheid ISNULL))
   AND (status <> 'Niet gerealiseerd verblijfsobject' AND
        status <> 'Verblijfsobject ingetrokkent' AND

--- a/packages/core/src/bag3d/core/sqlfiles/bag_verblijfsobjectactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bag_verblijfsobjectactueelbestaand.sql
@@ -30,7 +30,7 @@ WHERE (tijdstipinactieflv > ${reference_date} OR tijdstipinactieflv ISNULL)
        (tijdstipeindregistratielv > ${reference_date} OR
         tijdstipeindregistratielv ISNULL))
   AND (begingeldigheid <= ${reference_date} AND
-       (eindgeldigheid = begingelidgheid OR eindgeldigheid > ${reference_date} OR
+       (eindgeldigheid = begingeldigheid OR eindgeldigheid > ${reference_date} OR
         eindgeldigheid ISNULL))
   AND (status <> 'Niet gerealiseerd verblijfsobject' AND
        status <> 'Verblijfsobject ingetrokkent' AND

--- a/packages/core/src/bag3d/core/sqlfiles/bag_woonplaatsactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bag_woonplaatsactueelbestaand.sql
@@ -26,6 +26,6 @@ WHERE (tijdstipinactieflv > ${reference_date} OR tijdstipinactieflv ISNULL)
        (tijdstipeindregistratielv > ${reference_date} OR
         tijdstipeindregistratielv ISNULL))
   AND (begingeldigheid <= ${reference_date} AND
-       (eindgeldigheid = begingelidgheid OR eindgeldigheid > ${reference_date} OR
+       (eindgeldigheid = begingeldigheid OR eindgeldigheid > ${reference_date} OR
         eindgeldigheid ISNULL))
   AND status <> 'Woonplaats ingetrokken';

--- a/packages/core/src/bag3d/core/sqlfiles/bag_woonplaatsactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bag_woonplaatsactueelbestaand.sql
@@ -26,6 +26,6 @@ WHERE (tijdstipinactieflv > ${reference_date} OR tijdstipinactieflv ISNULL)
        (tijdstipeindregistratielv > ${reference_date} OR
         tijdstipeindregistratielv ISNULL))
   AND (begingeldigheid <= ${reference_date} AND
-       (eidgeldigheid = begingelidgheid OR eidgeldigheid > ${reference_date} OR
+       (eindgeldigheid = begingelidgheid OR eindgeldigheid > ${reference_date} OR
         eindgeldigheid ISNULL))
   AND status <> 'Woonplaats ingetrokken';


### PR DESCRIPTION
Quick fix, the BAG SQL statements contained the following errors: 
* eindgeldigheid was written as eidgeldigheid
* begingeldigheid was written as begingelidgheid

