### PR TITLE
Verbose AHN assets

### DIFF
--- a/packages/common/src/bag3d/common/utils/geodata.py
+++ b/packages/common/src/bag3d/common/utils/geodata.py
@@ -237,7 +237,7 @@ def ogr2postgres(
 
 
 def pdal_info(
-    pdal: AppImage, file_path: Path, with_all: bool = False
+    pdal: AppImage, file_path: Path, with_all: bool = False, verbose: bool = False
 ) -> Tuple[int, dict]:
     """Run 'pdal info' on a point cloud file.
 
@@ -256,7 +256,7 @@ def pdal_info(
     cmd_list.append("--all") if with_all else cmd_list.append("--metadata")
     cmd_list.append("{local_path}")
     return_code, output = pdal.execute(
-        "pdal", command=" ".join(cmd_list), local_path=file_path
+        "pdal", command=" ".join(cmd_list), local_path=file_path, silent=(not verbose)
     )
 
     return return_code, json.loads(output)

--- a/packages/core/src/bag3d/core/assets/ahn/index.py
+++ b/packages/core/src/bag3d/core/assets/ahn/index.py
@@ -33,7 +33,7 @@ def lasindex_ahn3(context, laz_files_ahn3):
 
     See https://lastools.osgeo.org/download/lasindex_README.txt.
     """
-    silent = (not context.op_execution_context.op_config["verbose"])
+    silent = not context.op_execution_context.op_config["verbose"]
     cmd_list = [
         "{exe}",
         "-i {local_path}",
@@ -44,8 +44,7 @@ def lasindex_ahn3(context, laz_files_ahn3):
     if context.op_execution_context.op_config["force"] is False:
         cmd_list.append("-dont_reindex")
     context.resources.lastools.app.execute(
-        "lasindex", " ".join(cmd_list), local_path=laz_files_ahn3.path,
-        silent=silent
+        "lasindex", " ".join(cmd_list), local_path=laz_files_ahn3.path, silent=silent
     )
 
 
@@ -76,7 +75,7 @@ def lasindex_ahn4(context, laz_files_ahn4):
 
     See https://lastools.osgeo.org/download/lasindex_README.txt.
     """
-    silent = (not context.op_execution_context.op_config["verbose"])
+    silent = not context.op_execution_context.op_config["verbose"]
     cmd_list = [
         "{exe}",
         "-i {local_path}",
@@ -87,8 +86,7 @@ def lasindex_ahn4(context, laz_files_ahn4):
     if context.op_execution_context.op_config["force"] is False:
         cmd_list.append("-dont_reindex")
     context.resources.lastools.app.execute(
-        "lasindex", " ".join(cmd_list), local_path=laz_files_ahn4.path,
-        silent=silent
+        "lasindex", " ".join(cmd_list), local_path=laz_files_ahn4.path, silent=silent
     )
 
 
@@ -119,7 +117,7 @@ def lasindex_ahn5(context, laz_files_ahn5):
 
     See https://lastools.osgeo.org/download/lasindex_README.txt.
     """
-    silent = (not context.op_execution_context.op_config["verbose"])
+    silent = not context.op_execution_context.op_config["verbose"]
     cmd_list = [
         "{exe}",
         "-i {local_path}",
@@ -130,6 +128,5 @@ def lasindex_ahn5(context, laz_files_ahn5):
     if context.op_execution_context.op_config["force"] is False:
         cmd_list.append("-dont_reindex")
     context.resources.lastools.app.execute(
-        "lasindex", " ".join(cmd_list), local_path=laz_files_ahn5.path,
-        silent=silent
+        "lasindex", " ".join(cmd_list), local_path=laz_files_ahn5.path, silent=silent
     )

--- a/packages/core/src/bag3d/core/assets/ahn/index.py
+++ b/packages/core/src/bag3d/core/assets/ahn/index.py
@@ -18,6 +18,12 @@ logger = get_dagster_logger("ahn.index")
             default_value=False,
             description="Force the re-index the file, even if it is already indexed.",
         ),
+        "verbose": Field(
+            bool,
+            default_value=False,
+            is_required=False,
+            description="Output stdout/stderr from lasindex",
+        ),
     },
     required_resource_keys={"lastools"},
     partitions_def=partition_definition_ahn,
@@ -27,6 +33,7 @@ def lasindex_ahn3(context, laz_files_ahn3):
 
     See https://lastools.osgeo.org/download/lasindex_README.txt.
     """
+    silent = (not context.op_execution_context.op_config["verbose"])
     cmd_list = [
         "{exe}",
         "-i {local_path}",
@@ -37,7 +44,8 @@ def lasindex_ahn3(context, laz_files_ahn3):
     if context.op_execution_context.op_config["force"] is False:
         cmd_list.append("-dont_reindex")
     context.resources.lastools.app.execute(
-        "lasindex", " ".join(cmd_list), local_path=laz_files_ahn3.path
+        "lasindex", " ".join(cmd_list), local_path=laz_files_ahn3.path,
+        silent=silent
     )
 
 
@@ -52,6 +60,12 @@ def lasindex_ahn3(context, laz_files_ahn3):
             bool,
             default_value=False,
             description="Force the re-index the file, even if it is already indexed.",
+        ),
+        "verbose": Field(
+            bool,
+            default_value=False,
+            is_required=False,
+            description="Output stdout/stderr from lasindex",
         ),
     },
     required_resource_keys={"lastools"},
@@ -62,6 +76,7 @@ def lasindex_ahn4(context, laz_files_ahn4):
 
     See https://lastools.osgeo.org/download/lasindex_README.txt.
     """
+    silent = (not context.op_execution_context.op_config["verbose"])
     cmd_list = [
         "{exe}",
         "-i {local_path}",
@@ -72,7 +87,8 @@ def lasindex_ahn4(context, laz_files_ahn4):
     if context.op_execution_context.op_config["force"] is False:
         cmd_list.append("-dont_reindex")
     context.resources.lastools.app.execute(
-        "lasindex", " ".join(cmd_list), local_path=laz_files_ahn4.path
+        "lasindex", " ".join(cmd_list), local_path=laz_files_ahn4.path,
+        silent=silent
     )
 
 
@@ -88,6 +104,12 @@ def lasindex_ahn4(context, laz_files_ahn4):
             default_value=False,
             description="Force the re-index the file, even if it is already indexed.",
         ),
+        "verbose": Field(
+            bool,
+            default_value=False,
+            is_required=False,
+            description="Output stdout/stderr from lasindex",
+        ),
     },
     required_resource_keys={"lastools"},
     partitions_def=partition_definition_ahn,
@@ -97,6 +119,7 @@ def lasindex_ahn5(context, laz_files_ahn5):
 
     See https://lastools.osgeo.org/download/lasindex_README.txt.
     """
+    silent = (not context.op_execution_context.op_config["verbose"])
     cmd_list = [
         "{exe}",
         "-i {local_path}",
@@ -107,5 +130,6 @@ def lasindex_ahn5(context, laz_files_ahn5):
     if context.op_execution_context.op_config["force"] is False:
         cmd_list.append("-dont_reindex")
     context.resources.lastools.app.execute(
-        "lasindex", " ".join(cmd_list), local_path=laz_files_ahn5.path
+        "lasindex", " ".join(cmd_list), local_path=laz_files_ahn5.path,
+        silent=silent
     )

--- a/packages/core/src/bag3d/core/assets/ahn/metadata.py
+++ b/packages/core/src/bag3d/core/assets/ahn/metadata.py
@@ -39,6 +39,12 @@ def metadata_table_ahn5(context):
             default_value=True,
             description="Force the re-compute of the metadata.",
         ),
+        "verbose": Field(
+            bool,
+            default_value=False,
+            is_required=False,
+            description="Output stdout/stderr from pdal",
+        ),
     },
     required_resource_keys={"pdal", "db_connection"},
     partitions_def=partition_definition_ahn,
@@ -48,7 +54,11 @@ def metadata_ahn3(context, laz_files_ahn3, metadata_table_ahn3, tile_index_ahn):
     computed with 'pdal info'.
     The metadata is loaded into the metadata database table."""
     return compute_load_metadata(
-        context, laz_files_ahn3, metadata_table_ahn3, tile_index_ahn
+        context,
+        laz_files_ahn3,
+        metadata_table_ahn3,
+        tile_index_ahn,
+        verbose=context.op_execution_context.op_config["verbose"],
     )
 
 
@@ -71,7 +81,11 @@ def metadata_ahn4(context, laz_files_ahn4, metadata_table_ahn4, tile_index_ahn):
     computed with 'pdal info'.
     The metadata is loaded into the metadata database table."""
     return compute_load_metadata(
-        context, laz_files_ahn4, metadata_table_ahn4, tile_index_ahn
+        context,
+        laz_files_ahn4,
+        metadata_table_ahn4,
+        tile_index_ahn,
+        verbose=context.op_execution_context.op_config["verbose"],
     )
 
 
@@ -94,7 +108,11 @@ def metadata_ahn5(context, laz_files_ahn5, metadata_table_ahn5, tile_index_ahn):
     computed with 'pdal info'.
     The metadata is loaded into the metadata database table."""
     return compute_load_metadata(
-        context, laz_files_ahn5, metadata_table_ahn5, tile_index_ahn
+        context,
+        laz_files_ahn5,
+        metadata_table_ahn5,
+        tile_index_ahn,
+        verbose=context.op_execution_context.op_config["verbose"],
     )
 
 
@@ -109,7 +127,11 @@ def metadata_ahn5(context, laz_files_ahn5, metadata_table_ahn5, tile_index_ahn):
 
 
 def compute_load_metadata(
-    context, laz_files_ahn, metadata_table_ahn, tile_index_ahn_pdok
+    context,
+    laz_files_ahn,
+    metadata_table_ahn,
+    tile_index_ahn_pdok,
+    verbose: bool = False,
 ):
     """Metadata of the AHN LAZ file, retrieved from the PDOK tile index and
     computed with 'pdal info'. The metadata is loaded into the metadata database table.
@@ -121,9 +143,10 @@ def compute_load_metadata(
         metadata_table_ahn (PostgresTableIdentifier): The metadata database table
             indentifier.
         tile_index_ahn_pdok (dict): Downloaded with `download_ahn_index`.
+        verbose (bool): Forward the stdout/stderr from pdal.
 
     Returns:
-
+        None
     """
     tile_id = context.partition_key
     conn = context.resources.db_connection.connect
@@ -139,6 +162,7 @@ def compute_load_metadata(
             context.resources.pdal.app,
             file_path=laz_files_ahn.path,
             with_all=context.op_execution_context.op_config["all"],
+            verbose=verbose,
         )
         if ret_code != 0:
             raise

--- a/packages/core/src/bag3d/core/assets/ahn/tile.py
+++ b/packages/core/src/bag3d/core/assets/ahn/tile.py
@@ -81,7 +81,13 @@ def regular_grid_200m(context):
             default_value=20,
             description="Passed on to the subprocess.ThreadPoolExecutor that calls "
             "las2las.",
-        )
+        ),
+        "verbose": Field(
+            bool,
+            default_value=False,
+            is_required=False,
+            description="Output stdout/stderr from las2las",
+        ),
     },
     deps={AssetKey(["ahn", "metadata_ahn3"])},
     required_resource_keys={"file_store", "lastools", "db_connection"},
@@ -95,6 +101,7 @@ def laz_tiles_ahn3_200m(context, regular_grid_200m, metadata_table_ahn3):
         ahn_version=3,
         cellsize=200,
         max_workers=context.op_execution_context.op_config["max_workers"],
+        verbose=context.op_execution_context.op_config["verbose"],
     )
 
 
@@ -105,7 +112,13 @@ def laz_tiles_ahn3_200m(context, regular_grid_200m, metadata_table_ahn3):
             default_value=20,
             description="Passed on to the subprocess.ThreadPoolExecutor that calls "
             "las2las.",
-        )
+        ),
+        "verbose": Field(
+            bool,
+            default_value=False,
+            is_required=False,
+            description="Output stdout/stderr from las2las",
+        ),
     },
     deps={AssetKey(["ahn", "metadata_ahn4"])},
     required_resource_keys={"file_store", "lastools", "db_connection"},
@@ -119,6 +132,7 @@ def laz_tiles_ahn4_200m(context, regular_grid_200m, metadata_table_ahn4):
         ahn_version=4,
         cellsize=200,
         max_workers=context.op_execution_context.op_config["max_workers"],
+        verbose=context.op_execution_context.op_config["verbose"],
     )
 
 
@@ -129,7 +143,13 @@ def laz_tiles_ahn4_200m(context, regular_grid_200m, metadata_table_ahn4):
             default_value=20,
             description="Passed on to the subprocess.ThreadPoolExecutor that calls "
             "las2las.",
-        )
+        ),
+        "verbose": Field(
+            bool,
+            default_value=False,
+            is_required=False,
+            description="Output stdout/stderr from las2las",
+        ),
     },
     deps={AssetKey(["ahn", "metadata_ahn5"])},
     required_resource_keys={"file_store", "lastools", "db_connection"},
@@ -143,12 +163,37 @@ def laz_tiles_ahn5_200m(context, regular_grid_200m, metadata_table_ahn5):
         ahn_version=5,
         cellsize=200,
         max_workers=context.op_execution_context.op_config["max_workers"],
+        verbose=context.op_execution_context.op_config["verbose"],
     )
 
 
 def partition_laz_with_grid(
-    context, metadata_table_ahn, regular_grid_200m, ahn_version, cellsize, max_workers
+    context,
+    metadata_table_ahn,
+    regular_grid_200m,
+    ahn_version,
+    cellsize,
+    max_workers,
+    verbose: bool = False,
 ):
+    """
+    Partitions LAZ files into tiles based on a regular grid.
+    Queries the PostgreSQL database to find the grid cells that overlap the AHN tile.
+    Calls `las2las` with ThreadPoolExecutor for cropping the AHN LAZ file with each
+    grid cell.
+
+    Args:
+        context: Dagster context object.
+        metadata_table_ahn: Metadata table for the AHN version.
+        regular_grid_200m: The 200m grid created by the `regular_grid_200m` asset.
+        ahn_version: The AHN version (e.g., 3, 4, or 5).
+        cellsize: The size of each grid cell in meters.
+        max_workers: Maximum number of threads for parallel processing.
+        verbose: Whether to suppress output from the subprocesses.
+
+    Returns:
+        None
+    """
     conn = context.resources.db_connection.connect
     query_params = {
         "grid_200m": regular_grid_200m,
@@ -201,7 +246,7 @@ def partition_laz_with_grid(
                     "las2las",
                     " ".join(cmd),
                     local_path=out_file,
-                    silent=True,
+                    silent=(not verbose),
                 )
             ] = tile
 


### PR DESCRIPTION
Add the `verbose` config option to the AHN assets that call an external tool in a subprocess. These are the `las_tiles_*`, `lasindex_*`, `metadata_*` assets.