### PR TITLE
handle requests.exceptions.ChunkedEncodingError

### DIFF
--- a/packages/common/src/bag3d/common/utils/requests.py
+++ b/packages/common/src/bag3d/common/utils/requests.py
@@ -71,6 +71,7 @@ def download_file(
     except (
         requests.exceptions.BaseHTTPError,
         requests.exceptions.HTTPError,
+        requests.exceptions.ChunkedEncodingError,
     ) as e:  # pragma: no cover
         logger.exception(e)
         return None


### PR DESCRIPTION
This pull request introduces a minor update to the exception handling in the `download_file` function. The change adds `requests.exceptions.ChunkedEncodingError` to the list of caught exceptions, improving robustness when handling network errors.

It may be worthwhile to implement resuming the download from the partial downloaded file on disk. Just an idea for the future.