### PR TITLE
Fix partition mismatch between ahn and reconstruction assets

### DIFF
--- a/packages/core/src/bag3d/core/assets/ahn/metadata.py
+++ b/packages/core/src/bag3d/core/assets/ahn/metadata.py
@@ -53,7 +53,9 @@ def metadata_table_ahn5(context):
     required_resource_keys={"pdal", "db_connection"},
     partitions_def=partition_definition_ahn,
 )
-def metadata_ahn3(context, laz_files_ahn3, metadata_table_ahn3, tile_index_ahn):
+def metadata_ahn3(
+    context, laz_files_ahn3, metadata_table_ahn3, tile_index_ahn
+) -> PostgresTable:
     """Metadata of the AHN3 LAZ file, retrieved from the PDOK tile index and
     computed with 'pdal info'.
     The metadata is loaded into the metadata database table."""
@@ -86,7 +88,9 @@ def metadata_ahn3(context, laz_files_ahn3, metadata_table_ahn3, tile_index_ahn):
     required_resource_keys={"pdal", "db_connection"},
     partitions_def=partition_definition_ahn,
 )
-def metadata_ahn4(context, laz_files_ahn4, metadata_table_ahn4, tile_index_ahn):
+def metadata_ahn4(
+    context, laz_files_ahn4, metadata_table_ahn4, tile_index_ahn
+) -> PostgresTable:
     """Metadata of the AHN4 LAZ file, retrieved from the PDOK tile index and
     computed with 'pdal info'.
     The metadata is loaded into the metadata database table."""
@@ -119,7 +123,9 @@ def metadata_ahn4(context, laz_files_ahn4, metadata_table_ahn4, tile_index_ahn):
     required_resource_keys={"pdal", "db_connection"},
     partitions_def=partition_definition_ahn,
 )
-def metadata_ahn5(context, laz_files_ahn5, metadata_table_ahn5, tile_index_ahn):
+def metadata_ahn5(
+    context, laz_files_ahn5, metadata_table_ahn5, tile_index_ahn
+) -> PostgresTable:
     """Metadata of the AHN5 LAZ file, retrieved from the PDOK tile index and
     computed with 'pdal info'.
     The metadata is loaded into the metadata database table."""
@@ -136,27 +142,30 @@ def metadata_ahn5(context, laz_files_ahn5, metadata_table_ahn5, tile_index_ahn):
 def metadata_ahn3_index(
     db_connection: DatabaseResource,
     metadata_table_ahn3: PostgresTable,
-):
+) -> PostgresTable:
     """Create indices on the AHN3 metadata table."""
     create_indices_metadata_table(db_connection, metadata_table_ahn3)
+    return metadata_table_ahn3
 
 
 @asset(deps=["metadata_ahn4"])
 def metadata_ahn4_index(
     db_connection: DatabaseResource,
     metadata_table_ahn4: PostgresTable,
-):
+) -> PostgresTable:
     """Create indices on the AHN4 metadata table."""
     create_indices_metadata_table(db_connection, metadata_table_ahn4)
+    return metadata_table_ahn4
 
 
 @asset(deps=["metadata_ahn5"])
 def metadata_ahn5_index(
     db_connection: DatabaseResource,
     metadata_table_ahn5: PostgresTable,
-):
+) -> PostgresTable:
     """Create indices on the AHN5 metadata table."""
     create_indices_metadata_table(db_connection, metadata_table_ahn5)
+    return metadata_table_ahn5
 
 
 def create_indices_metadata_table(

--- a/packages/core/src/bag3d/core/assets/ahn/metadata.py
+++ b/packages/core/src/bag3d/core/assets/ahn/metadata.py
@@ -53,9 +53,7 @@ def metadata_table_ahn5(context):
     required_resource_keys={"pdal", "db_connection"},
     partitions_def=partition_definition_ahn,
 )
-def metadata_ahn3(
-    context, laz_files_ahn3, metadata_table_ahn3, tile_index_ahn
-) -> PostgresTable:
+def metadata_ahn3(context, laz_files_ahn3, metadata_table_ahn3, tile_index_ahn):
     """Metadata of the AHN3 LAZ file, retrieved from the PDOK tile index and
     computed with 'pdal info'.
     The metadata is loaded into the metadata database table."""
@@ -88,9 +86,7 @@ def metadata_ahn3(
     required_resource_keys={"pdal", "db_connection"},
     partitions_def=partition_definition_ahn,
 )
-def metadata_ahn4(
-    context, laz_files_ahn4, metadata_table_ahn4, tile_index_ahn
-) -> PostgresTable:
+def metadata_ahn4(context, laz_files_ahn4, metadata_table_ahn4, tile_index_ahn):
     """Metadata of the AHN4 LAZ file, retrieved from the PDOK tile index and
     computed with 'pdal info'.
     The metadata is loaded into the metadata database table."""
@@ -123,9 +119,7 @@ def metadata_ahn4(
     required_resource_keys={"pdal", "db_connection"},
     partitions_def=partition_definition_ahn,
 )
-def metadata_ahn5(
-    context, laz_files_ahn5, metadata_table_ahn5, tile_index_ahn
-) -> PostgresTable:
+def metadata_ahn5(context, laz_files_ahn5, metadata_table_ahn5, tile_index_ahn):
     """Metadata of the AHN5 LAZ file, retrieved from the PDOK tile index and
     computed with 'pdal info'.
     The metadata is loaded into the metadata database table."""
@@ -142,7 +136,7 @@ def metadata_ahn5(
 def metadata_ahn3_index(
     db_connection: DatabaseResource,
     metadata_table_ahn3: PostgresTable,
-) -> PostgresTable:
+):
     """Create indices on the AHN3 metadata table."""
     create_indices_metadata_table(db_connection, metadata_table_ahn3)
     return metadata_table_ahn3
@@ -152,7 +146,7 @@ def metadata_ahn3_index(
 def metadata_ahn4_index(
     db_connection: DatabaseResource,
     metadata_table_ahn4: PostgresTable,
-) -> PostgresTable:
+):
     """Create indices on the AHN4 metadata table."""
     create_indices_metadata_table(db_connection, metadata_table_ahn4)
     return metadata_table_ahn4
@@ -162,7 +156,7 @@ def metadata_ahn4_index(
 def metadata_ahn5_index(
     db_connection: DatabaseResource,
     metadata_table_ahn5: PostgresTable,
-) -> PostgresTable:
+):
     """Create indices on the AHN5 metadata table."""
     create_indices_metadata_table(db_connection, metadata_table_ahn5)
     return metadata_table_ahn5

--- a/packages/core/src/bag3d/core/assets/reconstruction/reconstruction.py
+++ b/packages/core/src/bag3d/core/assets/reconstruction/reconstruction.py
@@ -56,9 +56,9 @@ class PartitionDefinition3DBagReconstruction(StaticPartitionsDefinition):
         schema=RECONSTRUCTION_INPUT_SCHEMA, table_tiles="tiles"
     ),
     ins={
-        "metadata_ahn3": AssetIn(key_prefix="ahn"),
-        "metadata_ahn4": AssetIn(key_prefix="ahn"),
-        "metadata_ahn5": AssetIn(key_prefix="ahn"),
+        "metadata_ahn3_index": AssetIn(key_prefix="ahn"),
+        "metadata_ahn4_index": AssetIn(key_prefix="ahn"),
+        "metadata_ahn5_index": AssetIn(key_prefix="ahn"),
         "tiles": AssetIn(key_prefix="input"),
         "index": AssetIn(key_prefix="input"),
         "reconstruction_input": AssetIn(key_prefix="input"),
@@ -90,9 +90,9 @@ def reconstructed_building_models_nl(
     tiles,
     index,
     reconstruction_input,
-    metadata_ahn3,
-    metadata_ahn4,
-    metadata_ahn5,
+    metadata_ahn3_index,
+    metadata_ahn4_index,
+    metadata_ahn5_index,
 ):
     """Generate the 3D building models by running the reconstruction sequentially
     within one partition.
@@ -103,9 +103,9 @@ def reconstructed_building_models_nl(
         reconstruction_input=reconstruction_input,
         index=index,
         tiles=tiles,
-        metadata_ahn3=metadata_ahn3,
-        metadata_ahn4=metadata_ahn4,
-        metadata_ahn5=metadata_ahn5,
+        metadata_ahn3=metadata_ahn3_index,
+        metadata_ahn4=metadata_ahn4_index,
+        metadata_ahn5=metadata_ahn5_index,
     )
 
     context.log.info(f"{roofer_toml=}")
@@ -232,7 +232,7 @@ def create_roofer_config(
     query_params_ahn5["metadata_ahn"] = metadata_ahn5
     laz_files_ahn3 = [
         r["filename"]
-        for r in context.resources.db_connection.connect.get_dict(
+        for r in context.resources.db_connection.connect.get7_dict(
             query_laz_tiles,
             query_params=query_params_ahn3,
         )

--- a/packages/core/src/bag3d/core/assets/reconstruction/reconstruction.py
+++ b/packages/core/src/bag3d/core/assets/reconstruction/reconstruction.py
@@ -232,7 +232,7 @@ def create_roofer_config(
     query_params_ahn5["metadata_ahn"] = metadata_ahn5
     laz_files_ahn3 = [
         r["filename"]
-        for r in context.resources.db_connection.connect.get7_dict(
+        for r in context.resources.db_connection.connect.get_dict(
             query_laz_tiles,
             query_params=query_params_ahn3,
         )

--- a/packages/core/tests/conftest.py
+++ b/packages/core/tests/conftest.py
@@ -357,7 +357,7 @@ def mock_asset_index():
 
 
 @pytest.fixture(scope="session")
-def mock_asset_metadata_ahn3():
+def mock_asset_metadata_ahn3_index():
     class MockIOManager(IOManager):
         def load_input(self, context):
             new_table = PostgresTableIdentifier("ahn", "metadata_ahn3")
@@ -373,7 +373,7 @@ def mock_asset_metadata_ahn3():
 
 
 @pytest.fixture(scope="session")
-def mock_asset_metadata_ahn4():
+def mock_asset_metadata_ahn4_index():
     class MockIOManager(IOManager):
         def load_input(self, context):
             new_table = PostgresTableIdentifier("ahn", "metadata_ahn4")
@@ -389,7 +389,7 @@ def mock_asset_metadata_ahn4():
 
 
 @pytest.fixture(scope="session")
-def mock_asset_metadata_ahn5():
+def mock_asset_metadata_ahn5_index():
     class MockIOManager(IOManager):
         def load_input(self, context):
             new_table = PostgresTableIdentifier("ahn", "metadata_ahn5")

--- a/packages/core/tests/conftest.py
+++ b/packages/core/tests/conftest.py
@@ -367,7 +367,7 @@ def mock_asset_metadata_ahn3_index():
             raise NotImplementedError()
 
     return SourceAsset(
-        key=AssetKey(["ahn", "metadata_ahn3"]),
+        key=AssetKey(["ahn", "metadata_ahn3_index"]),
         io_manager_def=MockIOManager(),
     )
 
@@ -383,7 +383,7 @@ def mock_asset_metadata_ahn4_index():
             raise NotImplementedError()
 
     return SourceAsset(
-        key=AssetKey(["ahn", "metadata_ahn4"]),
+        key=AssetKey(["ahn", "metadata_ahn4_index"]),
         io_manager_def=MockIOManager(),
     )
 
@@ -399,7 +399,7 @@ def mock_asset_metadata_ahn5_index():
             raise NotImplementedError()
 
     return SourceAsset(
-        key=AssetKey(["ahn", "metadata_ahn5"]),
+        key=AssetKey(["ahn", "metadata_ahn5_index"]),
         io_manager_def=MockIOManager(),
     )
 

--- a/packages/core/tests/test_integration.py
+++ b/packages/core/tests/test_integration.py
@@ -111,9 +111,9 @@ def test_integration_reconstruction_and_export(
     mock_asset_reconstruction_input,
     mock_asset_tiles,
     mock_asset_index,
-    mock_asset_metadata_ahn3,
-    mock_asset_metadata_ahn4,
-    mock_asset_metadata_ahn5,
+    mock_asset_metadata_ahn3_index,
+    mock_asset_metadata_ahn4_index,
+    mock_asset_metadata_ahn5_index,
 ):
     # update quadtree
     og_quadtree = test_data_dir / "quadtree.tsv"
@@ -182,9 +182,9 @@ def test_integration_reconstruction_and_export(
             mock_asset_reconstruction_input,
             mock_asset_tiles,
             mock_asset_index,
-            mock_asset_metadata_ahn3,
-            mock_asset_metadata_ahn4,
-            mock_asset_metadata_ahn5,
+            mock_asset_metadata_ahn3_index,
+            mock_asset_metadata_ahn4_index,
+            mock_asset_metadata_ahn5_index,
             *reconstruction_assets,
             *all_export_assets,
         ],


### PR DESCRIPTION
With the ahn rework in #255 the ahn laz assets (ahn_metadata) are now directly connected to the reconstruction asset. But the ahn assets use the ahn partitioning scheme, the reconstruction assets use the reconstruction partitioning scheme. Since both assets are partitioned, dagster is trying to match the ahn to reconstruction partition-by-partition, but it has no way of connecting the two partioning schemes, because they are different.

This doesn't happen in the integration test, because the reconstruction integration starts with the reconstruction asset, not all the way from the ahn metadata. So somehow this is not an issue there...