### PR TITLE
Do not return records if filename is NULL in ahn metadata.

### DIFF
--- a/packages/core/src/bag3d/core/assets/reconstruction/reconstruction.py
+++ b/packages/core/src/bag3d/core/assets/reconstruction/reconstruction.py
@@ -214,7 +214,7 @@ def create_roofer_config(
                   ON st_intersects(r.geometrie, m.boundary)
              JOIN {tile_index} AS i USING (fid)
     WHERE i.tile_id = {tile_id}
-      AND m.pdal_info -> 'filename' IS DISTINCT FROM jsonb('""')
+      AND NULLIF(m.pdal_info ->> 'filename', '') IS NOT NULL
       AND m.hash IS NOT NULL
     ORDER BY m.tile_id, m.insert_time DESC;
     """)


### PR DESCRIPTION
Fixes the None value in the ahn file paths in the roofer config.