### PR TITLE
Ahn5 pdal issue

### DIFF
--- a/docker/pipeline/bag3d-core.dockerfile
+++ b/docker/pipeline/bag3d-core.dockerfile
@@ -1,4 +1,4 @@
-FROM 3dgi/3dbag-pipeline-tools:2025.08.07 AS develop
+FROM 3dgi/3dbag-pipeline-tools:2025.08.15 AS develop
 ARG VERSION=develop
 ARG BAG3D_PIPELINE_LOCATION=/opt/3dbag-pipeline
 

--- a/docker/pipeline/bag3d-floors-estimation.dockerfile
+++ b/docker/pipeline/bag3d-floors-estimation.dockerfile
@@ -1,4 +1,4 @@
-FROM 3dgi/3dbag-pipeline-tools:2025.08.07 AS develop
+FROM 3dgi/3dbag-pipeline-tools:2025.08.15 AS develop
 ARG VERSION=develop
 ARG BAG3D_PIPELINE_LOCATION=/opt/3dbag-pipeline
 

--- a/docker/pipeline/bag3d-party-walls.dockerfile
+++ b/docker/pipeline/bag3d-party-walls.dockerfile
@@ -1,4 +1,4 @@
-FROM 3dgi/3dbag-pipeline-tools:2025.08.07 AS develop
+FROM 3dgi/3dbag-pipeline-tools:2025.08.15 AS develop
 ARG VERSION=develop
 ARG BAG3D_PIPELINE_LOCATION=/opt/3dbag-pipeline
 

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -109,13 +109,13 @@ FROM roofer AS geoflow-old
 ARG JOBS=2
 ARG BAG3D_PIPELINE_LOCATION=/opt/3dbag-pipeline
 
-COPY --from=3dgi/geoflow-bundle-builder:2025.08.07 /usr/local/bin/geof $BAG3D_PIPELINE_LOCATION/tools/bin/geof
-COPY --from=3dgi/geoflow-bundle-builder:2025.08.07 /export /export
-COPY --from=3dgi/geoflow-bundle-builder:2025.08.07 /usr/local/src/FileGDB/lib/. /usr/local/src/FileGDB/lib
-COPY --from=3dgi/geoflow-bundle-builder:2025.08.07 /usr/local/lib/libfgdbunixrtl.so /usr/local/lib/libfgdbunixrtl.so
-COPY --from=3dgi/geoflow-bundle-builder:2025.08.07 /usr/local/lib/LASlib /export/usr/local/lib/
-COPY --from=3dgi/geoflow-bundle-builder:2025.08.07 /usr/local/lib/gdalplugins /export/usr/local/lib/
-COPY --from=3dgi/geoflow-bundle-builder:2025.08.07 /usr/local/lib/geoflow-plugins/. $BAG3D_PIPELINE_LOCATION/tools/share/geoflow-bundle/plugins
+COPY --from=3dgi/geoflow-bundle-builder:2025.08.15 /usr/local/bin/geof $BAG3D_PIPELINE_LOCATION/tools/bin/geof
+COPY --from=3dgi/geoflow-bundle-builder:2025.08.15 /export /export
+COPY --from=3dgi/geoflow-bundle-builder:2025.08.15 /usr/local/src/FileGDB/lib/. /usr/local/src/FileGDB/lib
+COPY --from=3dgi/geoflow-bundle-builder:2025.08.15 /usr/local/lib/libfgdbunixrtl.so /usr/local/lib/libfgdbunixrtl.so
+COPY --from=3dgi/geoflow-bundle-builder:2025.08.15 /usr/local/lib/LASlib /export/usr/local/lib/
+COPY --from=3dgi/geoflow-bundle-builder:2025.08.15 /usr/local/lib/gdalplugins /export/usr/local/lib/
+COPY --from=3dgi/geoflow-bundle-builder:2025.08.15 /usr/local/lib/geoflow-plugins/. $BAG3D_PIPELINE_LOCATION/tools/share/geoflow-bundle/plugins
 ENV GF_PLUGIN_FOLDER=$BAG3D_PIPELINE_LOCATION/tools/share/geoflow-bundle/plugins
 
 RUN echo /export/usr/local/lib >> /etc/ld.so.conf.d/geoflow.conf; \

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -11,6 +11,7 @@ LABEL org.opencontainers.image.description="Builder image for building the 3dbag
 LABEL org.opencontainers.image.version=$VERSION
 LABEL org.opencontainers.image.licenses="(MIT OR Apache-2.0)"
 
+
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \

--- a/packages/core/src/bag3d/core/assets/ahn/metadata.py
+++ b/packages/core/src/bag3d/core/assets/ahn/metadata.py
@@ -216,10 +216,10 @@ def compute_load_metadata(
         )
         if ret_code != 0:
             raise
-    # if pdal fails store nothing in the table
+    # if pdal fails store only the filename in the table (to be used later)
     except Exception as e:
-        context.log.exception(e)
-        out_info = {}
+        context.log.exception(f"PDAL failed for tile {tile_id}: {e}")
+        out_info = {"filename": laz_files_ahn.path}
 
     set_json_dumps(dumps=partial(json.dumps, ensure_ascii=False))
 


### PR DESCRIPTION
This is what caused the error.

When we started using AHN5 (about a year ago), we had noticed that pdal was failing for all the new tiles with this error:

```
PDAL: readers.las: Global encoding WKT flag not set for point format 6 - 10.
```
(you can read more about this issue [here](https://gis.stackexchange.com/questions/413191/python-pdal-error-reading-format-1-4-las-file-readers-las-error-global-enco) )

Back then, we had decided that, even if pdal failed, the downloading should continue and only an *empy dict* should be stored in the DB.

However, this solution stopped working when we started [using the pdal_info column from that table to get the filename from](https://github.com/3DBAG/3dbag-pipeline/blob/d9c5d5d02f476466881083abc2c259d21c884bd3/packages/core/src/bag3d/core/assets/reconstruction/reconstruction.py#L211)

I fixed this by storing the filename in the column, even if pdal fails - this will allow for the pipeline to continue.


TO LOOK INTO: Even the tiles that have a succesfull pdal info output they have this error:
```
"stac": {"status": "error", "message": "Failed to create STAC Feature with missing key. 
```

TO LOOK INTO2: One more thing that I noticed is that we are running pdal info with the flag `--all`. This takes WAAAAY too long for each tile. Indicatively, it took 4' to download a single tile and 38 to get the metadata:

<img width="1056" height="172" alt="image" src="https://github.com/user-attachments/assets/e24a0241-4a31-437f-aeed-4b271eca14ff" />

 Are we actually using this pdal output for anything else apart from retrieving the filename? Maybe in validation? I couldn't find anything. If not, I suggest removing it. 

 Also in this PR, I am building the new tools image.