### PR TITLE
not storing metadata for tiles without hash matched

### DIFF
--- a/packages/core/src/bag3d/core/assets/ahn/download.py
+++ b/packages/core/src/bag3d/core/assets/ahn/download.py
@@ -186,7 +186,11 @@ def laz_files_ahn3(context, config: LazFilesConfig, md5_ahn3, tile_index_ahn):
 
         # Let's try to re-download the file once
         if not first_validation:
-            logger.info(format_laz_log(fpath, "Removing"))
+            logger.info(
+                format_laz_log(
+                    fpath, "First validation failed. Removing and retrying..."
+                )
+            )
             fpath.unlink()
             lazdownload = download_ahn_laz(
                 fpath=fpath, url_laz=url_laz, verify_ssl=verify_ssl
@@ -195,7 +199,7 @@ def laz_files_ahn3(context, config: LazFilesConfig, md5_ahn3, tile_index_ahn):
                 sha_reference=md5_ahn3, sha_func=HashChunkwise("md5")
             )
             if not second_validation:
-                logger.error(format_laz_log(fpath, "ERROR"))
+                logger.error(format_laz_log(fpath, "ERROR: second validation failed!"))
                 lazdownload = LAZDownload(
                     url=None,
                     path=Path(),
@@ -206,7 +210,7 @@ def laz_files_ahn3(context, config: LazFilesConfig, md5_ahn3, tile_index_ahn):
                     size=0.0,
                 )
         else:
-            logger.debug(format_laz_log(fpath, "OK"))
+            logger.debug(format_laz_log(fpath, "Validation OK"))
 
     return Output(lazdownload, metadata=lazdownload.asdict())
 
@@ -245,7 +249,11 @@ def laz_files_ahn4(context, config: LazFilesConfig, md5_ahn4, tile_index_ahn):
 
         # Let's try to re-download the file once
         if not first_validation:
-            logger.info(format_laz_log(fpath, "Removing"))
+            logger.info(
+                format_laz_log(
+                    fpath, "First validation failed. Removing and retrying..."
+                )
+            )
             fpath.unlink()
             lazdownload = download_ahn_laz(
                 fpath=fpath,
@@ -256,7 +264,8 @@ def laz_files_ahn4(context, config: LazFilesConfig, md5_ahn4, tile_index_ahn):
                 sha_reference=md5_ahn4, sha_func=HashChunkwise("md5")
             )
             if not second_validation:
-                logger.error(format_laz_log(fpath, "ERROR"))
+                logger.error(format_laz_log(fpath, "ERROR: second validation failed!"))
+                fpath.unlink()
                 lazdownload = LAZDownload(
                     url=None,
                     path=Path(),
@@ -267,7 +276,7 @@ def laz_files_ahn4(context, config: LazFilesConfig, md5_ahn4, tile_index_ahn):
                     size=0.0,
                 )
         else:
-            logger.debug(format_laz_log(fpath, "OK"))
+            logger.debug(format_laz_log(fpath, "Validation OK"))
 
     return Output(lazdownload, metadata=lazdownload.asdict())
 
@@ -303,7 +312,11 @@ def laz_files_ahn5(context, config: LazFilesConfig, sha256_ahn5, tile_index_ahn)
         )
         # Let's try to re-download the file once
         if not first_validation:
-            logger.info(format_laz_log(fpath, "Removing"))
+            logger.info(
+                format_laz_log(
+                    fpath, "First validation failed. Removing and retrying..."
+                )
+            )
             fpath.unlink()
             lazdownload = download_ahn_laz(
                 fpath=fpath,
@@ -314,7 +327,7 @@ def laz_files_ahn5(context, config: LazFilesConfig, sha256_ahn5, tile_index_ahn)
                 sha_reference=sha256_ahn5, sha_func=HashChunkwise("sha256")
             )
             if not second_validation:
-                logger.error(format_laz_log(fpath, "ERROR"))
+                logger.error(format_laz_log(fpath, "ERROR: second validation failed!"))
                 lazdownload = LAZDownload(
                     url=None,
                     path=Path(),
@@ -325,7 +338,7 @@ def laz_files_ahn5(context, config: LazFilesConfig, sha256_ahn5, tile_index_ahn)
                     size=0.0,
                 )
         else:
-            logger.debug(format_laz_log(fpath, "OK"))
+            logger.debug(format_laz_log(fpath, "Validation OK"))
 
     return Output(lazdownload, metadata=lazdownload.asdict())
 
@@ -380,14 +393,14 @@ def download_ahn_laz(
         )
     else:  # pragma: no cover
         logger.info(format_laz_log(fpath, "File already downloaded"))
+        success = True
+        file_size = round(fpath.stat().st_size / 1e6, 2)
+        is_new = False
         if force_download:
             logger.info(format_laz_log(fpath, "Forcing re-download"))
             file_size, fpath, is_new, success, url_laz = download_laz(
                 file_size, fpath, is_new, nr_retries, success, url, url_laz, verify_ssl
             )
-        success = True
-        file_size = round(fpath.stat().st_size / 1e6, 2)
-        is_new = False
     return LAZDownload(
         url=url_laz,
         path=fpath,

--- a/packages/core/src/bag3d/core/assets/ahn/metadata.py
+++ b/packages/core/src/bag3d/core/assets/ahn/metadata.py
@@ -200,6 +200,13 @@ def compute_load_metadata(
     """
     tile_id = context.partition_key
     conn = context.resources.db_connection.connect
+    if not laz_files_ahn.success or laz_files_ahn.hash_name is None:
+        context.log.info(
+            f"LAZ tile {tile_id} has not been successfully downloaded."
+            f"Skipping metadata computation..."
+        )
+        return Output(None)
+
     if not laz_files_ahn.new:
         if not context.op_execution_context.op_execution_context.op_config["force"]:
             context.log.info(


### PR DESCRIPTION
I found 2 main issues:

1) The success of the LAZ files was set to True even when we had the `force_download`  option - which was the case in this run

2) When storing the PDAL output to the metadata_ahn* tables,  there was no filter for the unsuccessful LAZ tiles.
I added a filter to skip the metadata storage if the download or the hashes have failed. 

This is what happened in this  release's run:

Hashes are failing, the last download object gets a success=False and an empty path (.)  but this is information is not used anywhere for filtering.

<img width="1041" height="552" alt="image" src="https://github.com/user-attachments/assets/d49e9caa-61d7-41e7-a03d-b92ec1f4b073" />

Then the lazdownload object is fed into pdal and of course there is no output:

<img width="548" height="84" alt="image" src="https://github.com/user-attachments/assets/786154d2-994b-4593-a635-300534e214bb" />

The metadata is still stored in the metadata_table. Example from the metadata_ahn4 table (I have cleaned it now):

<img width="737" height="237" alt="image" src="https://github.com/user-attachments/assets/e08142e4-9e2c-4e20-ac94-e3f1732ae899" />


Specifically, these tiles had failed hashes:

AHN3 = 25gn2, 25hz2, 26cz1
AHN4 = 06hn2, 11fn2, 11fz2


I suggest we skip them and we ask Adriaan about it (why are the hashes diverging?)

For AHN5 the issue was different and it had to do with what I did in my previous commits. 

I suggest we make a fresh download for all AHN5


