### PR TITLE
Pc 2025.08.21

### DIFF
--- a/docker/pipeline/bag3d-core.dockerfile
+++ b/docker/pipeline/bag3d-core.dockerfile
@@ -1,4 +1,4 @@
-FROM 3dgi/3dbag-pipeline-tools:2025.08.19 AS develop
+FROM 3dgi/3dbag-pipeline-tools:2025.08.25 AS develop
 ARG VERSION=develop
 ARG BAG3D_PIPELINE_LOCATION=/opt/3dbag-pipeline
 

--- a/docker/pipeline/bag3d-floors-estimation.dockerfile
+++ b/docker/pipeline/bag3d-floors-estimation.dockerfile
@@ -1,4 +1,4 @@
-FROM 3dgi/3dbag-pipeline-tools:2025.08.19 AS develop
+FROM 3dgi/3dbag-pipeline-tools:2025.08.25 AS develop
 ARG VERSION=develop
 ARG BAG3D_PIPELINE_LOCATION=/opt/3dbag-pipeline
 

--- a/docker/pipeline/bag3d-party-walls.dockerfile
+++ b/docker/pipeline/bag3d-party-walls.dockerfile
@@ -1,4 +1,4 @@
-FROM 3dgi/3dbag-pipeline-tools:2025.08.19 AS develop
+FROM 3dgi/3dbag-pipeline-tools:2025.08.25 AS develop
 ARG VERSION=develop
 ARG BAG3D_PIPELINE_LOCATION=/opt/3dbag-pipeline
 

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -56,7 +56,7 @@ RUN bash $BAG3D_PIPELINE_LOCATION/tools-build.sh \
     --clean
 
 ENV GDAL_DATA=$BAG3D_PIPELINE_LOCATION/tools/share/gdal
-ENV PROJ_DATA=/usr/share/proj
+ENV PROJ_DATA=$BAG3D_PIPELINE_LOCATION/tools/share/proj
 RUN echo $BAG3D_PIPELINE_LOCATION/tools/lib >> /etc/ld.so.conf.d/3dbag-pipeline-tools.conf
 
 FROM tools AS tyler
@@ -64,14 +64,15 @@ ARG JOBS=2
 ARG BAG3D_PIPELINE_LOCATION=/opt/3dbag-pipeline
 
 COPY --from=3dgi/tyler:0.3.13 /usr/src/tyler/resources/geof /usr/src/tyler/resources/geof
-COPY --from=3dgi/tyler:0.3.13 /usr/local/share/proj /usr/local/share/proj
 COPY --from=3dgi/tyler:0.3.13 /lib/ /tyler/lib/
 COPY --from=3dgi/tyler:0.3.13 /lib64/ /tyler/lib64/
 COPY --from=3dgi/tyler:0.3.13 /usr/ /tyler/usr/
 COPY --from=3dgi/tyler:0.3.13 /usr/local/bin/tyler $BAG3D_PIPELINE_LOCATION/tools/bin/tyler
+# Include Dutch transformation grids
+COPY --from=3dgi/tyler:0.3.13 /usr/local/share/proj/nl_nsgi_nlgeo2018.tif $PROJ_DATA/nl_nsgi_nlgeo2018.tif
+COPY --from=3dgi/tyler:0.3.13 /usr/local/share/proj/nl_nsgi_rdtrans2018.tif $PROJ_DATA/nl_nsgi_rdtrans2018.tif
 
 COPY --from=3dgi/tyler-multiformat:0.4.0-alpha10 /usr/src/tyler/resources/geof /usr/src/tyler/resources/geof
-COPY --from=3dgi/tyler-multiformat:0.4.0-alpha10 /usr/local/share/proj /usr/local/share/proj
 COPY --from=3dgi/tyler-multiformat:0.4.0-alpha10 /lib/ /tyler/lib/
 COPY --from=3dgi/tyler-multiformat:0.4.0-alpha10 /lib64/ /tyler/lib64/
 COPY --from=3dgi/tyler-multiformat:0.4.0-alpha10 /usr/ /tyler/usr/
@@ -102,8 +103,6 @@ ARG BAG3D_PIPELINE_LOCATION=/opt/3dbag-pipeline
 COPY --from=3dgi/roofer:v1.0.0-beta.3 /opt/roofer/bin/. $BAG3D_PIPELINE_LOCATION/tools/bin/
 COPY --from=3dgi/roofer:v1.0.0-beta.3 /opt/roofer/share/proj $BAG3D_PIPELINE_LOCATION/tools/share/proj
 COPY --from=3dgi/roofer:v1.0.0-beta.3 /opt/roofer/share/gdal $BAG3D_PIPELINE_LOCATION/tools/share/gdal
-ENV GDAL_DATA=$BAG3D_PIPELINE_LOCATION/tools/share/gdal
-ENV PROJ_DATA=$BAG3D_PIPELINE_LOCATION/tools/share/proj
 
 # We only need this until we replace the old geoflow with roofer
 FROM roofer AS geoflow-old

--- a/packages/core/src/bag3d/core/assets/export/archive.py
+++ b/packages/core/src/bag3d/core/assets/export/archive.py
@@ -111,7 +111,7 @@ def geopackage_nl(context):
     path_nl_zip = path_nl.with_suffix(".gpkg.zip")
     # Remove existing
     path_nl_zip.unlink(missing_ok=True)
-    cmd = ["{exe}", str(path_nl_zip), str(path_nl)]
+    cmd = ["{exe}", "--junk-paths", str(path_nl_zip), str(path_nl)]
     cmd = " ".join(cmd)
     context.resources.gdal.app.execute("sozip", cmd)
 

--- a/packages/core/src/bag3d/core/assets/export/metadata.py
+++ b/packages/core/src/bag3d/core/assets/export/metadata.py
@@ -199,7 +199,7 @@ ASSET_DEPENDENCIES_FOR_METADATA = [
     required_resource_keys={"file_store", "version"},
 )
 def metadata(context: AssetExecutionContext):
-    """3D BAG metadata for distribution.
+    """3DBAG metadata for distribution.
     Metadata schema follows the Dutch metadata profile for geographical data,
     https://geonovum.github.io/Metadata-ISO19115/.
 
@@ -263,15 +263,15 @@ def metadata(context: AssetExecutionContext):
     metadata = {
         "identificationInfo": {
             "citation": {
-                "title": "3D BAG",
+                "title": "3DBAG",
                 "date": date_3dbag,
                 "dateType": "creation",
                 "edition": version_3dbag,
                 "identifier": uuid_3dbag,
             },
-            "abstract": "De 3D BAG is een up-to-date landsdekkende dataset met 3D gebouwmodellen van Nederland. De 3D BAG is open data. Het bevat 3D modellen op verscheidene detailniveaus welke zijn gegenereerd door de combinatie van twee open datasets: de pand-gegevens uit de BAG en de hoogtegegevens uit de AHN. De 3D BAG wordt regelmatig geüpdatet met de meest recente openlijk beschikbare pand- en hoogtegegevens.",
+            "abstract": "De 3DBAG is een up-to-date landsdekkende dataset met 3D gebouwmodellen van Nederland. De 3DBAG is open data. Het bevat 3D modellen op verscheidene detailniveaus welke zijn gegenereerd door de combinatie van twee open datasets: de pand-gegevens uit de BAG en de hoogtegegevens uit de AHN. De 3DBAG wordt regelmatig geüpdatet met de meest recente openlijk beschikbare pand- en hoogtegegevens.",
             "pointOfContact": {
-                "organisationName": "3D BAG",
+                "organisationName": "3DBAG",
                 "contactInfo": {
                     "address": {
                         "country": "Nederland",
@@ -287,7 +287,7 @@ def metadata(context: AssetExecutionContext):
                     "otherConstraints": [
                         {
                             "href": "http://creativecommons.org/licenses/by/4.0/?ref=chooser-v1",
-                            "text": "Naamensvermelding verplicht, 3D BAG door de 3D geoinformation onderzoeksgroep (TU Delft) en 3DGI",
+                            "text": "Naamensvermelding verplicht, 3DBAG door de 3D geoinformation onderzoeksgroep (TU Delft) en 3DGI",
                         }
                     ],
                 }

--- a/packages/core/src/bag3d/core/assets/export/validate.py
+++ b/packages/core/src/bag3d/core/assets/export/validate.py
@@ -1006,7 +1006,7 @@ def check_formats(input) -> TileResults:
     specs = Specs3DBAGResource()
     file_id = tile_id.replace("/", "-")
     planarity_n_tol = 20.0
-    planarity_d2p_tol = 0.0001
+    planarity_d2p_tol = 0.01
     snap_tol = 0.0001
     cj_results = cityjson(
         validation=validation,


### PR DESCRIPTION
This pull request includes several updates to the Docker build files and minor adjustments to the core export and validation logic. The main focus is on updating the Docker base images, improving the handling of projection data, and refining export and validation parameters.

**Docker image updates and projection data handling:**

* Updated the base image version for `bag3d-core`, `bag3d-floors-estimation`, and `bag3d-party-walls` Dockerfiles to use `3dgi/3dbag-pipeline-tools:2025.08.25` for consistency and to include the latest pipeline tools. [[1]](diffhunk://#diff-a23c03dc14c210b0f307182d4342e3df4798cb471ffd5d263ea893afd0ccaa7bL1-R1) [[2]](diffhunk://#diff-a016f424cbe895782b890d5aff89230bf6db1724ed297538946f4d4faeeac4d3L1-R1) [[3]](diffhunk://#diff-faa26b0b4c987216ed15937c6a3182925fdcae5b179f64b9491a8cff1494a9adL1-R1)
* Changed the `PROJ_DATA` environment variable in `docker/tools/Dockerfile` to point to the pipeline's internal `tools/share/proj` directory, and ensured Dutch transformation grids are included in the image.
* Removed redundant environment variable settings for `GDAL_DATA` and `PROJ_DATA` in the tools Dockerfile, as these are now set earlier and handled more consistently.

**Export and validation logic improvements:**

* Modified the export logic in `archive.py` to add the `--junk-paths` option to the sozip command, ensuring that file paths are not stored inside the zip archive.
* Increased the `planarity_d2p_tol` tolerance in the CityJSON validation from `0.0001` to `0.01`, allowing for slightly greater deviation in planarity checks.