### PR TITLE
Fix dagster concurrency

### DIFF
--- a/docker/dagster/dagster.yaml
+++ b/docker/dagster/dagster.yaml
@@ -1,6 +1,10 @@
 run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
+  tag_concurrency_limits:
+    - key: "dagster/concurrency_key"
+      value: "laz_download"
+      limit: 1
 
 run_launcher:
   module: dagster.core.launcher

--- a/docker/dagster/dagster.yaml
+++ b/docker/dagster/dagster.yaml
@@ -1,10 +1,6 @@
 run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
-  tag_concurrency_limits:
-    - key: "dagster/concurrency_key"
-      value: "laz_download"
-      limit: 1
 
 run_launcher:
   module: dagster.core.launcher
@@ -35,3 +31,10 @@ local_artifact_storage:
   config:
     base_dir:
       env: DAGSTER_HOME
+
+concurrency:
+  runs:
+    tag_concurrency_limits:
+      - key: "dagster/concurrency_key"
+        value: "laz_download"
+        limit: 1

--- a/packages/core/src/bag3d/core/assets/ahn/download.py
+++ b/packages/core/src/bag3d/core/assets/ahn/download.py
@@ -157,7 +157,8 @@ class LazFilesConfig(Config):
 @asset(
     required_resource_keys={"file_store"},
     partitions_def=partition_definition_ahn,
-    op_tags={"dagster/concurrency_key": "laz_download"},
+    tags={"dagster/concurrency_key": "laz_download"},
+    pool="laz_download"
 )
 def laz_files_ahn3(context, config: LazFilesConfig, md5_ahn3, tile_index_ahn):
     """AHN3 LAZ files as they are downloaded from PDOK.
@@ -211,7 +212,8 @@ def laz_files_ahn3(context, config: LazFilesConfig, md5_ahn3, tile_index_ahn):
 @asset(
     required_resource_keys={"file_store"},
     partitions_def=partition_definition_ahn,
-    op_tags={"dagster/concurrency_key": "laz_download"},
+    tags={"dagster/concurrency_key": "laz_download"},
+    pool="laz_download"
 )
 def laz_files_ahn4(context, config: LazFilesConfig, md5_ahn4, tile_index_ahn):
     """AHN4 LAZ files as they are downloaded from PDOK.
@@ -268,7 +270,8 @@ def laz_files_ahn4(context, config: LazFilesConfig, md5_ahn4, tile_index_ahn):
 @asset(
     required_resource_keys={"file_store"},
     partitions_def=partition_definition_ahn,
-    op_tags={"dagster/concurrency_key": "laz_download"},
+    tags={"dagster/concurrency_key": "laz_download"},
+    pool="laz_download"
 )
 def laz_files_ahn5(context, config: LazFilesConfig, sha256_ahn5, tile_index_ahn):
     """AHN5 LAZ files as they are downloaded from PDOK.

--- a/packages/core/src/bag3d/core/assets/ahn/download.py
+++ b/packages/core/src/bag3d/core/assets/ahn/download.py
@@ -157,6 +157,7 @@ class LazFilesConfig(Config):
 @asset(
     required_resource_keys={"file_store"},
     partitions_def=partition_definition_ahn,
+    op_tags={"dagster/concurrency_key": "laz_download"},
 )
 def laz_files_ahn3(context, config: LazFilesConfig, md5_ahn3, tile_index_ahn):
     """AHN3 LAZ files as they are downloaded from PDOK.
@@ -210,6 +211,7 @@ def laz_files_ahn3(context, config: LazFilesConfig, md5_ahn3, tile_index_ahn):
 @asset(
     required_resource_keys={"file_store"},
     partitions_def=partition_definition_ahn,
+    op_tags={"dagster/concurrency_key": "laz_download"},
 )
 def laz_files_ahn4(context, config: LazFilesConfig, md5_ahn4, tile_index_ahn):
     """AHN4 LAZ files as they are downloaded from PDOK.
@@ -266,6 +268,7 @@ def laz_files_ahn4(context, config: LazFilesConfig, md5_ahn4, tile_index_ahn):
 @asset(
     required_resource_keys={"file_store"},
     partitions_def=partition_definition_ahn,
+    op_tags={"dagster/concurrency_key": "laz_download"},
 )
 def laz_files_ahn5(context, config: LazFilesConfig, sha256_ahn5, tile_index_ahn):
     """AHN5 LAZ files as they are downloaded from PDOK.

--- a/packages/core/src/bag3d/core/jobs.py
+++ b/packages/core/src/bag3d/core/jobs.py
@@ -21,9 +21,6 @@ job_ahn3 = define_asset_job(
     name="ahn3",
     description="Make sure that the available AHN 3 LAZ files are present on disk, "
     "and their metadata is recorded.",
-    executor_def=multiprocess_executor.configured(
-        {"max_concurrent": int(getenv("BAG3D_CONCURRENCY_JOB_AHN3", 1))}
-    ),
     selection=AssetSelection.assets(["ahn", "laz_files_ahn3"])
     | AssetSelection.assets(["ahn", "metadata_ahn3"])
     | AssetSelection.assets(["ahn", "lasindex_ahn3"]),
@@ -33,9 +30,6 @@ job_ahn4 = define_asset_job(
     name="ahn4",
     description="Make sure that the available AHN 4 LAZ files are present on disk, "
     "and their metadata is recorded.",
-    executor_def=multiprocess_executor.configured(
-        {"max_concurrent": int(getenv("BAG3D_CONCURRENCY_JOB_AHN4", 1))}
-    ),
     selection=AssetSelection.assets(["ahn", "laz_files_ahn4"])
     | AssetSelection.assets(["ahn", "metadata_ahn4"])
     | AssetSelection.assets(["ahn", "lasindex_ahn4"]),
@@ -45,9 +39,6 @@ job_ahn5 = define_asset_job(
     name="ahn5",
     description="Make sure that the available AHN 5 LAZ files are present on disk, "
     "and their metadata is recorded.",
-    executor_def=multiprocess_executor.configured(
-        {"max_concurrent": int(getenv("BAG3D_CONCURRENCY_JOB_AHN5", 1))}
-    ),
     selection=AssetSelection.assets(["ahn", "laz_files_ahn5"])
     | AssetSelection.assets(["ahn", "metadata_ahn5"])
     | AssetSelection.assets(["ahn", "lasindex_ahn5"]),


### PR DESCRIPTION
This pull request refactors how concurrency is managed for the AHN LAZ file download assets in Dagster. Instead of configuring concurrency at the job executor level, it introduces asset-level concurrency controls using Dagster's tag-based concurrency limits and pools. This approach centralizes and simplifies concurrency management for these assets.

Concurrency management improvements:

* Added a `tag_concurrency_limits` section to `dagster.yaml` to restrict concurrent runs with the tag `dagster/concurrency_key` set to `laz_download` to a limit of 1.
* Updated the `laz_files_ahn3`, `laz_files_ahn4`, and `laz_files_ahn5` asset definitions to include the tag `dagster/concurrency_key: laz_download` and assign them to the `laz_download` pool, ensuring that only one of these assets can run concurrently. [[1]](diffhunk://#diff-a7c7be75218ae8e1fca7ee46a2775bfa5ae3e12089a6b2a0f14619987a0b8637R160-R161) [[2]](diffhunk://#diff-a7c7be75218ae8e1fca7ee46a2775bfa5ae3e12089a6b2a0f14619987a0b8637R215-R216) [[3]](diffhunk://#diff-a7c7be75218ae8e1fca7ee46a2775bfa5ae3e12089a6b2a0f14619987a0b8637R273-R274)

Job configuration simplification:

* Removed per-job `multiprocess_executor` concurrency configuration from the `ahn3`, `ahn4`, and `ahn5` jobs, as concurrency is now managed at the asset level. [[1]](diffhunk://#diff-94cab80c17b9ad4f4de8aa8acfeb7ecd409aac251316ac3d0f340c3a02dd9f28L24-L26) [[2]](diffhunk://#diff-94cab80c17b9ad4f4de8aa8acfeb7ecd409aac251316ac3d0f340c3a02dd9f28L36-L38) [[3]](diffhunk://#diff-94cab80c17b9ad4f4de8aa8acfeb7ecd409aac251316ac3d0f340c3a02dd9f28L48-L50)

<img width="2482" height="1120" alt="image" src="https://github.com/user-attachments/assets/be8473df-a79c-42f7-8d17-f129ec4607ee" />
