### PR TITLE
358 revert the downloading of bgt

### DIFF
--- a/docs/source_datasets.md
+++ b/docs/source_datasets.md
@@ -50,7 +50,11 @@ There can always be some variation in the point density between buildings and ev
 
 ## BGT
 
-TBD
+The [Basisregistratie Grootschalige Topografie (BGT)](https://www.kadaster.nl/zakelijk/registraties/basisregistraties/bgt) is the Key Register for Large-scale Topography of the Netherlands. It provides detailed topographic information with geometric accuracy of 30 centimeters or better, covering roads, water bodies, terrain, buildings, and other topographic features.
+
+The dataset is maintained collaboratively by municipalities, provinces, water boards, and Rijkswaterstaat, ensuring comprehensive and up-to-date topographic coverage across the Netherlands.
+
+For the 3DBAG pipeline, BGT data is used to provide additional context and validation for building footprints and to enhance the topographic understanding of the environment surrounding buildings. 
 
 ## TOP10NL
 

--- a/docs/source_datasets.md
+++ b/docs/source_datasets.md
@@ -4,6 +4,7 @@ They are downloaded with the `source_input` job and they are:
 
 - BAG  
 - AHN
+- BGT     ([xsd](https://register.geostandaarden.nl/gmlapplicatieschema/imgeo/2.1.1/imgeo-simple.xsd)|[Code Lists](https://register.geostandaarden.nl/waardelijst/imgeo/))
 - TOP10NL ([xsd](https://register.geostandaarden.nl/gmlapplicatieschema/top10nl/1.2.0/top10nl.xsd)|[Code Lists](https://register.geostandaarden.nl/waardelijst/top10nl/20190708))
 
 
@@ -46,6 +47,10 @@ For the 3DBAG we use a smart combination of AHN3, AHN4 and AHN5. AHN4 was acaqui
 For the latest versions of the 3DBAG we use both AHN3 and AHN4 but also recently AHN5 when available. This is to guarantee the best possible 3D reconstruction for each building. If a building has no mutation since the acquisition of AHN3, we pick the pointcloud with the best point coverage. This reduces the odds that a building contains small errors due to large no data gaps in the point cloud.
 
 There can always be some variation in the point density between buildings and even within one building. There can be no data gaps in the point cloud, caused by an occlusion through objects, water ponds on roofs and scan angle. The number of available points, their distribution and accurate classification has a very significant impact on the quality of the reconstructed models. The quality attributes that we calculate for and assign to each model provide an indication of this quality.
+
+## BGT
+
+TBD
 
 ## TOP10NL
 

--- a/packages/common/src/bag3d/common/utils/geodata.py
+++ b/packages/common/src/bag3d/common/utils/geodata.py
@@ -131,7 +131,7 @@ def attributes_dict(attributes_str: str) -> List[dict]:
         # Skip empty lines
         if not i.strip():
             continue
-            
+
         adict = {}
         aname, specs = i.split(":")
         try:

--- a/packages/common/src/bag3d/common/utils/geodata.py
+++ b/packages/common/src/bag3d/common/utils/geodata.py
@@ -128,6 +128,10 @@ def attributes_dict(attributes_str: str) -> List[dict]:
     ret = []
     _astr = attributes_str.strip("\n").strip().split("\n")
     for i in _astr:
+        # Skip empty lines
+        if not i.strip():
+            continue
+            
         adict = {}
         aname, specs = i.split(":")
         try:
@@ -136,7 +140,7 @@ def attributes_dict(attributes_str: str) -> List[dict]:
         except ValueError:
             # 'inOnderzoek: Integer(Boolean) (0.0)'
             atype, contstraints = specs.strip(), ""
-        adict["name"] = aname
+        adict["name"] = aname.strip()
         adict["type"] = atype + ")"
         if contstraints == "":
             adict["constraints"] = None

--- a/packages/common/src/bag3d/common/utils/geodata.py
+++ b/packages/common/src/bag3d/common/utils/geodata.py
@@ -133,23 +133,51 @@ def attributes_dict(attributes_str: str) -> List[dict]:
             continue
 
         adict = {}
-        aname, specs = i.split(":")
+
+        # Split on first colon to get attribute name and rest
+        parts = i.split(":", 1)
+
+        # reject lines without at least one colon
+        if len(parts) != 2:
+            continue
+
+        # get the name
+        aname = parts[0].strip()
+        specs_full = parts[1].strip()
+
+        # Check if there's a comment and remove it
+        if ", comment=" in specs_full:
+            specs = specs_full.split(", comment=", 1)[0]
+        else:
+            specs = specs_full
+
         try:
+            # Handle different formats:
             # 'String (0.0) NOT NULL'
-            atype, contstraints = specs.strip().split(")")
+            # 'Date'
+            # 'Integer(Boolean) (0.0)'
+            if ")" in specs and " " in specs:
+                # Find the last closing parenthesis and split there
+                last_paren = specs.rfind(")")
+                atype = specs[: last_paren + 1]
+                constraints = specs[last_paren + 1 :].strip()
+            else:
+                # Simple type like 'Date', 'DateTime'
+                atype = specs.strip()
+                constraints = ""
+
         except ValueError:
             # 'inOnderzoek: Integer(Boolean) (0.0)'
-            atype, contstraints = specs.strip(), ""
-        adict["name"] = aname.strip()
-        adict["type"] = atype + ")"
-        if contstraints == "":
+            atype = specs.strip()
+            constraints = ""
+
+        adict["name"] = aname
+        adict["type"] = atype
+
+        if constraints == "" or constraints is None:
             adict["constraints"] = None
         else:
-            adict["constraints"] = TableColumnConstraints(
-                other=[
-                    contstraints.strip(),
-                ]
-            )
+            adict["constraints"] = TableColumnConstraints(other=[constraints.strip()])
         ret.append(adict)
     return ret
 

--- a/packages/core/src/bag3d/core/asset_groups.py
+++ b/packages/core/src/bag3d/core/asset_groups.py
@@ -38,7 +38,7 @@ top10nl_assets = load_assets_from_package_module(
     package_module=top10nl, key_prefix="top10nl", group_name=TOP10NL
 )
 
-source_assets = ahn_assets + bag_assets + bgt_assets + top10nl_assets
+source_assets = ahn_assets + bag_assets + top10nl_assets
 
 input_assets = load_assets_from_package_module(
     package_module=input, key_prefix="input", group_name=INPUT

--- a/packages/core/src/bag3d/core/asset_groups.py
+++ b/packages/core/src/bag3d/core/asset_groups.py
@@ -3,6 +3,7 @@ from dagster import load_assets_from_package_module
 from bag3d.core.assets import (
     ahn,
     bag,
+    bgt,
     top10nl,
     input,
     reconstruction,
@@ -12,6 +13,7 @@ from bag3d.core.assets import (
 )
 
 BAG = "bag"
+BGT = "bgt"
 TOP10NL = "top10nl"
 AHN = "ahn"
 INPUT = "input"
@@ -28,11 +30,15 @@ bag_assets = load_assets_from_package_module(
     package_module=bag, key_prefix="bag", group_name=BAG
 )
 
+bgt_assets = load_assets_from_package_module(
+    package_module=bgt, key_prefix="bgt", group_name=BGT
+)
+
 top10nl_assets = load_assets_from_package_module(
     package_module=top10nl, key_prefix="top10nl", group_name=TOP10NL
 )
 
-source_assets = ahn_assets + bag_assets + top10nl_assets
+source_assets = ahn_assets + bag_assets + bgt_assets + top10nl_assets
 
 input_assets = load_assets_from_package_module(
     package_module=input, key_prefix="input", group_name=INPUT

--- a/packages/core/src/bag3d/core/assets/bgt/download.py
+++ b/packages/core/src/bag3d/core/assets/bgt/download.py
@@ -27,7 +27,7 @@ def extract_bgt(context) -> Output[Path]:
         url_api="https://api.pdok.nl/lv/bgt/download/v1_0",
         featuretypes=context.op_config["featuretypes"],
         data_format="gmllight",
-        geofilter=context.op_config["geofilter"],
+        geofilter=context.op_execution_context.op_config.get("geofilter"),
         download_dir=context.resources.file_store.data_dir,
     )
     extract_path = Path(metadata["Extract Path"].value)

--- a/packages/core/src/bag3d/core/assets/bgt/download.py
+++ b/packages/core/src/bag3d/core/assets/bgt/download.py
@@ -25,10 +25,10 @@ def extract_bgt(context) -> Output[Path]:
     metadata = download_extract(
         dataset="bgt",
         url_api="https://api.pdok.nl/lv/bgt/download/v1_0",
-        featuretypes=context.op_config["featuretypes"],
+        featuretypes=context.op_execution_context.op_config["featuretypes"],
         data_format="gmllight",
         geofilter=context.op_execution_context.op_config.get("geofilter"),
-        download_dir=context.resources.file_store.data_dir,
+        download_dir=context.resources.file_store.file_store.data_dir,
     )
     extract_path = Path(metadata["Extract Path"].value)
     context.log.info(f"Downloaded {extract_path}")

--- a/packages/core/src/bag3d/core/assets/bgt/download.py
+++ b/packages/core/src/bag3d/core/assets/bgt/download.py
@@ -20,7 +20,7 @@ from bag3d.common.types import Path
     required_resource_keys={"gdal", "file_store"},
 )
 def extract_bgt(context) -> Output[Path]:
-    """The TOP10NL extract downloaded from the PDOK API, containing the 'pand' and
+    """The BGT extract downloaded from the PDOK API, containing the 'pand' and
     'wegdeel' layers."""
     metadata = download_extract(
         dataset="bgt",

--- a/packages/core/src/bag3d/core/assets/bgt/download.py
+++ b/packages/core/src/bag3d/core/assets/bgt/download.py
@@ -33,7 +33,7 @@ def extract_bgt(context) -> Output[Path]:
     extract_path = Path(metadata["Extract Path"].value)
     context.log.info(f"Downloaded {extract_path}")
     context.log.info("Starting ogrinfo to extract metadata...")
-    context.log.info({context.op_execution_context.op_config["featuretypes"]})
+    context.log.info(context.op_execution_context.op_config["featuretypes"])
     metadata["XSD"] = (
         "http://register.geostandaarden.nl/gmlapplicatieschema/imgeo/2.1.1/imgeo-simple.xsd"
     )

--- a/packages/core/src/bag3d/core/assets/bgt/download.py
+++ b/packages/core/src/bag3d/core/assets/bgt/download.py
@@ -32,6 +32,8 @@ def extract_bgt(context) -> Output[Path]:
     )
     extract_path = Path(metadata["Extract Path"].value)
     context.log.info(f"Downloaded {extract_path}")
+    context.log.info("Starting ogrinfo to extract metadata...")
+    context.log.info({context.op_execution_context.op_config["featuretypes"]})
     metadata["XSD"] = (
         "http://register.geostandaarden.nl/gmlapplicatieschema/imgeo/2.1.1/imgeo-simple.xsd"
     )

--- a/packages/core/src/bag3d/core/assets/bgt/download.py
+++ b/packages/core/src/bag3d/core/assets/bgt/download.py
@@ -40,7 +40,7 @@ def extract_bgt(context) -> Output[Path]:
             context,
             dataset="bgt",
             extract_path=extract_path,
-            feature_types=context.op_config["featuretypes"],
+            feature_types=context.op_execution_context.op_config["featuretypes"],
             xsd=metadata["XSD"],
         )
     )

--- a/packages/core/src/bag3d/core/assets/bgt/download.py
+++ b/packages/core/src/bag3d/core/assets/bgt/download.py
@@ -1,0 +1,48 @@
+from dagster import asset, Output, Field
+
+from bag3d.common.utils.requests import download_extract
+from bag3d.common.utils.geodata import ogrinfo, add_info
+from bag3d.common.types import Path
+
+
+@asset(
+    config_schema={
+        "featuretypes": Field(
+            list,
+            default_value=["pand", "wegdeel"],
+            description="The feature types to download.",
+            is_required=False,
+        ),
+        "geofilter": Field(
+            str, description="WKT of the polygonal extent", is_required=False
+        ),
+    },
+    required_resource_keys={"gdal", "file_store"},
+)
+def extract_bgt(context) -> Output[Path]:
+    """The TOP10NL extract downloaded from the PDOK API, containing the 'pand' and
+    'wegdeel' layers."""
+    metadata = download_extract(
+        dataset="bgt",
+        url_api="https://api.pdok.nl/lv/bgt/download/v1_0",
+        featuretypes=context.op_config["featuretypes"],
+        data_format="gmllight",
+        geofilter=context.op_config["geofilter"],
+        download_dir=context.resources.file_store.data_dir,
+    )
+    extract_path = Path(metadata["Extract Path"].value)
+    context.log.info(f"Downloaded {extract_path}")
+    metadata["XSD"] = (
+        "http://register.geostandaarden.nl/gmlapplicatieschema/imgeo/2.1.1/imgeo-simple.xsd"
+    )
+    info = dict(
+        ogrinfo(
+            context,
+            dataset="bgt",
+            extract_path=extract_path,
+            feature_types=context.op_config["featuretypes"],
+            xsd=metadata["XSD"],
+        )
+    )
+    add_info(metadata, info)
+    return Output(extract_path, metadata=metadata)

--- a/packages/core/src/bag3d/core/assets/bgt/load.py
+++ b/packages/core/src/bag3d/core/assets/bgt/load.py
@@ -1,0 +1,77 @@
+from dagster import asset, Output
+
+from bag3d.common.utils.database import (
+    postgrestable_from_query,
+    load_sql,
+    drop_table,
+    create_schema,
+)
+from bag3d.common.utils.geodata import ogr2postgres
+from bag3d.common.types import PostgresTableIdentifier
+
+SCHEMA_STAGE = "stage_bgt"
+SCHEMA_PROD = "bgt"
+
+
+@asset(required_resource_keys={"db_connection", "gdal"})
+def stage_bgt_pand(context, extract_bgt) -> Output[PostgresTableIdentifier]:
+    """The BGT Pand layer, loaded as-is from the extract."""
+    create_schema(context, SCHEMA_STAGE)
+    xsd = "http://register.geostandaarden.nl/gmlapplicatieschema/imgeo/2.1.1/imgeo-simple.xsd"
+    new_table = PostgresTableIdentifier(SCHEMA_STAGE, "pand")
+    # Need to explicitly drop the table just in case (...couz GDAL...)
+    drop_table(context, new_table)
+    metadata = ogr2postgres(
+        context=context,
+        dataset="bgt",
+        xsd=xsd,
+        feature_type="pand",
+        extract_path=extract_bgt,
+        new_table=new_table,
+    )
+    return Output(new_table, metadata=metadata)
+
+
+@asset(required_resource_keys={"db_connection"}, op_tags={"kind": "sql"})
+def bgt_pandactueelbestaand(context, stage_bgt_pand) -> Output[PostgresTableIdentifier]:
+    """The BGT Pand layer that only contains the current (timely) and physically
+    existing objects, and repaired polygons."""
+    create_schema(context, SCHEMA_PROD)
+    new_table = PostgresTableIdentifier(SCHEMA_PROD, "pandactueelbestaand")
+    query = load_sql(query_params={"pand_tbl": stage_bgt_pand, "new_table": new_table})
+    metadata = postgrestable_from_query(context, query, new_table)
+    return Output(new_table, metadata=metadata)
+
+
+@asset(required_resource_keys={"db_connection", "gdal"})
+def stage_bgt_wegdeel(context, extract_bgt) -> Output[PostgresTableIdentifier]:
+    """The BGT Wegdeel layer, loaded as-is from the extract."""
+    create_schema(context, SCHEMA_STAGE)
+    xsd = "http://register.geostandaarden.nl/gmlapplicatieschema/imgeo/2.1.1/imgeo-simple.xsd"
+    new_table = PostgresTableIdentifier(SCHEMA_STAGE, "wegdeel")
+    # Need to explicitly drop the table just in case (...couz GDAL...)
+    drop_table(context, new_table)
+    metadata = ogr2postgres(
+        context=context,
+        dataset="bgt",
+        xsd=xsd,
+        new_table=new_table,
+        extract_path=extract_bgt,
+        feature_type="wegdeel",
+    )
+    return Output(new_table, metadata=metadata)
+
+
+@asset(required_resource_keys={"db_connection"}, op_tags={"kind": "sql"})
+def bgt_wegdeelactueelbestaand(
+    context, stage_bgt_wegdeel
+) -> Output[PostgresTableIdentifier]:
+    """The BGT Wegdeel layer that only contains the current (timely) and physically
+    existing objects, and repaired polygons."""
+    create_schema(context, SCHEMA_PROD)
+    new_table = PostgresTableIdentifier(SCHEMA_PROD, "wegdeelactueelbestaand")
+    query = load_sql(
+        query_params={"wegdeel_tbl": stage_bgt_wegdeel, "new_table": new_table}
+    )
+    metadata = postgrestable_from_query(context, query, new_table)
+    return Output(new_table, metadata=metadata)

--- a/packages/core/src/bag3d/core/code_location.py
+++ b/packages/core/src/bag3d/core/code_location.py
@@ -2,6 +2,7 @@ from dagster import Definitions
 
 from bag3d.common.resources import resource_defs
 from bag3d.core.asset_groups import (
+    bgt_assets,
     source_assets,
     input_assets,
     reconstruction_assets,
@@ -26,6 +27,7 @@ from bag3d.core.jobs import (
 )
 
 all_assets = [
+    *bgt_assets,
     *source_assets,
     *input_assets,
     *reconstruction_assets,

--- a/packages/core/src/bag3d/core/code_location.py
+++ b/packages/core/src/bag3d/core/code_location.py
@@ -34,6 +34,7 @@ all_assets = [
 ]
 
 all_jobs = [
+    job_bgt,
     job_source_input,
     job_ahn_tile_index,
     job_ahn3,

--- a/packages/core/src/bag3d/core/code_location.py
+++ b/packages/core/src/bag3d/core/code_location.py
@@ -10,6 +10,7 @@ from bag3d.core.asset_groups import (
     release_assets,
 )
 from bag3d.core.jobs import (
+    job_bgt,
     job_source_input,
     job_ahn_tile_index,
     job_ahn3,

--- a/packages/core/src/bag3d/core/jobs.py
+++ b/packages/core/src/bag3d/core/jobs.py
@@ -5,6 +5,7 @@ from dagster import define_asset_job, AssetSelection, multiprocess_executor
 job_bgt = define_asset_job(
     name="bgt",
     description="Load the latest BGT Pand, Wegdeel layers.",
+    selection=AssetSelection.assets(["bgt", "extract_bgt"]),
 )
 
 job_ahn_tile_index = define_asset_job(

--- a/packages/core/src/bag3d/core/jobs.py
+++ b/packages/core/src/bag3d/core/jobs.py
@@ -5,7 +5,7 @@ from dagster import define_asset_job, AssetSelection, multiprocess_executor
 job_bgt = define_asset_job(
     name="bgt",
     description="Load the latest BGT Pand, Wegdeel layers.",
-    selection=AssetSelection.assets(["bgt", "extract_bgt"]),
+    selection=AssetSelection.groups("bgt"),
 )
 
 job_ahn_tile_index = define_asset_job(

--- a/packages/core/src/bag3d/core/jobs.py
+++ b/packages/core/src/bag3d/core/jobs.py
@@ -2,6 +2,11 @@ from os import getenv
 from dagster import define_asset_job, AssetSelection, multiprocess_executor
 
 
+job_bgt = define_asset_job(
+    name="bgt",
+    description="Load the latest BGT Pand, Wegdeel layers.",
+)
+
 job_ahn_tile_index = define_asset_job(
     name="ahn_tile_index",
     description="Get the tile index (bladwijzer), md5 hashes of the LAZ files and "

--- a/packages/core/src/bag3d/core/sqlfiles/bgt_pandactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bgt_pandactueelbestaand.sql
@@ -1,0 +1,50 @@
+DROP SEQUENCE IF EXISTS bgt_pandactueelbestaand_fid_seq;
+CREATE SEQUENCE bgt_pandactueelbestaand_fid_seq;
+
+DROP TABLE IF EXISTS ${new_table} CASCADE;
+CREATE TABLE ${new_table} AS
+WITH dump AS (SELECT ogc_fid
+                   , (st_dump(geometrie2d)).geom AS dumpgeom
+              FROM ${pand_tbl})
+   , lines AS (SELECT ogc_fid
+                    , st_makevalid(st_curvetoline(dumpgeom)) AS geometrie
+               FROM dump
+               WHERE geometrytype(dumpgeom) = 'CURVEPOLYGON')
+   , polys AS (SELECT ogc_fid
+                    , st_makevalid(dumpgeom) AS geometrie
+               FROM dump
+               WHERE geometrytype(dumpgeom) = 'POLYGON')
+   , fixed AS (SELECT ogc_fid
+                    , st_multi(geometrie)::geometry(MultiPolygon, 28992)
+               FROM lines
+               WHERE geometrytype(geometrie) = 'POLYGON'
+                  OR geometrytype(geometrie) = 'MULTIPOLYGON'
+               UNION
+               SELECT ogc_fid
+                    , st_multi(geometrie)::geometry(MultiPolygon, 28992)
+               FROM polys
+               WHERE geometrytype(geometrie) = 'POLYGON'
+                  OR geometrytype(geometrie) = 'MULTIPOLYGON')
+   , withgeom AS (SELECT gml_id
+                       , objectbegintijd
+                       , objecteindtijd
+                       , "identificatie.namespace" AS namespace
+                       , "identificatie.lokaalid"  AS lokaalid
+                       , tijdstipregistratie
+                       , eindregistratie
+                       , lv_publicatiedatum
+                       , bronhouder
+                       , inonderzoek
+                       , relatievehoogteligging
+                       , bgt_status
+                       , plus_status
+                       , identificatiebagpnd
+                  FROM ${pand_tbl} p
+                           LEFT JOIN fixed USING (ogc_fid)
+                  WHERE p.eindregistratie ISNULL
+                    AND p.objecteindtijd ISNULL
+                    AND p.bgt_status = 'bestaand')
+SELECT NEXTVAL('bgt_pandactueelbestaand_fid_seq') AS fid, withgeom.*
+FROM withgeom;
+
+DROP SEQUENCE IF EXISTS bgt_pandactueelbestaand_fid_seq;

--- a/packages/core/src/bag3d/core/sqlfiles/bgt_pandactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bgt_pandactueelbestaand.sql
@@ -16,6 +16,7 @@ WITH dump AS (SELECT ogc_fid
                WHERE geometrytype(dumpgeom) = 'POLYGON')
    , fixed AS (SELECT ogc_fid
                     , st_multi(geometrie)::geometry(MultiPolygon, 28992)
+                    as geometrie
                FROM lines
                WHERE geometrytype(geometrie) = 'POLYGON'
                   OR geometrytype(geometrie) = 'MULTIPOLYGON'
@@ -39,6 +40,7 @@ WITH dump AS (SELECT ogc_fid
                        , bgt_status
                        , plus_status
                        , identificatiebagpnd
+                       , fixed.geometrie
                   FROM ${pand_tbl} p
                            LEFT JOIN fixed USING (ogc_fid)
                   WHERE p.eindregistratie ISNULL

--- a/packages/core/src/bag3d/core/sqlfiles/bgt_wegdeelactueelbestaand.sql
+++ b/packages/core/src/bag3d/core/sqlfiles/bgt_wegdeelactueelbestaand.sql
@@ -1,0 +1,49 @@
+DROP SEQUENCE IF EXISTS bgt_wegdeelactueelbestaand_fid_seq;
+CREATE SEQUENCE bgt_wegdeelactueelbestaand_fid_seq;
+
+DROP TABLE IF EXISTS ${new_table} CASCADE;
+CREATE TABLE ${new_table} AS
+WITH dump AS (SELECT ogc_fid, (st_dump(geometrie2d)).geom AS dumpgeom
+              FROM ${wegdeel_tbl})
+   , lines AS (SELECT ogc_fid, st_makevalid(st_curvetoline(dumpgeom)) AS geometrie
+               FROM dump
+               WHERE geometrytype(dumpgeom) = 'CURVEPOLYGON')
+   , polys AS (SELECT ogc_fid, st_makevalid(dumpgeom) AS geometrie
+               FROM dump
+               WHERE geometrytype(dumpgeom) = 'POLYGON')
+   , fixed AS (SELECT ogc_fid, st_multi(geometrie)::geometry(MultiPolygon, 28992)
+               FROM lines
+               WHERE geometrytype(geometrie) = 'POLYGON'
+                  OR geometrytype(geometrie) = 'MULTIPOLYGON'
+               UNION
+               SELECT ogc_fid, st_multi(geometrie)::geometry(MultiPolygon, 28992)
+               FROM polys
+               WHERE geometrytype(geometrie) = 'POLYGON'
+                  OR geometrytype(geometrie) = 'MULTIPOLYGON')
+   , withgeom AS (SELECT gml_id
+                       , objectbegintijd
+                       , objecteindtijd
+                       , "identificatie.namespace" AS namespace
+                       , "identificatie.lokaalid"  AS locaalid
+                       , tijdstipregistratie
+                       , eindregistratie
+                       , lv_publicatiedatum
+                       , bronhouder
+                       , inonderzoek
+                       , relatievehoogteligging
+                       , bgt_status
+                       , plus_status
+                       , bgt_functie
+                       , plus_functie
+                       , optalud
+                       , bgt_fysiekvoorkomen
+                       , plus_fysiekvoorkomen
+                  FROM ${wegdeel_tbl} p
+                           LEFT JOIN fixed USING (ogc_fid)
+                  WHERE p.eindregistratie ISNULL
+                    AND p.objecteindtijd ISNULL
+                    AND p.bgt_status = 'bestaand')
+SELECT NEXTVAL('bgt_wegdeelactueelbestaand_fid_seq') AS fid, withgeom.*
+FROM withgeom;
+
+DROP SEQUENCE IF EXISTS bgt_wegdeelactueelbestaand_fid_seq;

--- a/packages/core/tests/conftest.py
+++ b/packages/core/tests/conftest.py
@@ -44,12 +44,6 @@ def deployment_server():
     )
 
     yield server
-    #
-    # with server.connection as conn:
-    #     conn.run(f"rm -rf {server.target_dir}")
-    #     conn.run(f"rm -rf {server.public_dir}")
-    #     conn.run(f"mkdir -p {server.target_dir}")
-    #     conn.run(f"mkdir -p {server.public_dir}")
 
 
 @pytest.fixture(scope="session")
@@ -223,6 +217,25 @@ def context_top10nl(database, wkt_testarea, file_store, gdal):
             "geofilter": wkt_testarea,
             "featuretypes": [
                 "gebouw",
+            ],
+        },
+        resources={
+            "gdal": gdal,
+            "db_connection": database,
+            "file_store": file_store,
+            "version": VersionResource("test_version"),
+        },
+    )
+
+
+@pytest.fixture
+def context_bgt(database, wkt_testarea, file_store, gdal):
+    yield build_op_context(
+        partition_key="01cz1",
+        op_config={
+            "geofilter": wkt_testarea,
+            "featuretypes": [
+                "pand",
             ],
         },
         resources={

--- a/packages/core/tests/test_assets_bgt.py
+++ b/packages/core/tests/test_assets_bgt.py
@@ -1,0 +1,9 @@
+import pytest
+from bag3d.core.assets.bgt.download import extract_bgt
+
+
+@pytest.mark.slow
+def test_extract_bgt(context_bgt):
+    """Does the complete asset work?"""
+    res = extract_bgt(context_bgt)
+    assert res.value.exists()

--- a/packages/core/tests/test_assets_top10nl.py
+++ b/packages/core/tests/test_assets_top10nl.py
@@ -1,16 +1,9 @@
 import pytest
 from bag3d.core.assets.top10nl.download import extract_top10nl
-from bag3d.core.assets.bgt.download import extract_bgt
 
 
 @pytest.mark.slow
 def test_extract_top10nl(context_top10nl):
     """Does the complete asset work?"""
     res = extract_top10nl(context_top10nl)
-    assert res.value.exists()
-
-
-def test_extract_bgt(context_bgt):
-    """Does the complete asset work?"""
-    res = extract_bgt(context_bgt)
     assert res.value.exists()

--- a/packages/core/tests/test_assets_top10nl.py
+++ b/packages/core/tests/test_assets_top10nl.py
@@ -1,9 +1,16 @@
 import pytest
-from bag3d.core.assets.top10nl import download
+from bag3d.core.assets.top10nl.download import extract_top10nl
+from bag3d.core.assets.bgt.download import extract_bgt
 
 
 @pytest.mark.slow
 def test_extract_top10nl(context_top10nl):
     """Does the complete asset work?"""
-    res = download.extract_top10nl(context_top10nl)
+    res = extract_top10nl(context_top10nl)
+    assert res.value.exists()
+
+
+def test_extract_bgt(context_bgt):
+    """Does the complete asset work?"""
+    res = extract_bgt(context_bgt)
     assert res.value.exists()


### PR DESCRIPTION
Now this is ready for review. 
I decided to keep the roads since they might be useful for the project. If not, I will remove it later. 
I had to change how the attributes are processed in packages/common/src/bag3d/common/utils/geodata.py
because it seems that BGT comes with comments because of the XSD schema. Eg:

objectBeginTijd: Date, comment=objectBeginTijd: Datum waarop het object bij de bronhouder is ontstaan.
objectEindTijd: Date, comment=objectEindTijd: Datum waarop het object bij de bronhouder niet meer geldig is.
identificatie.namespace: String (0.0), comment=identificatie.namespace: Unieke verwijzing naar een registratie van objecten.
identificatie.lokaalID: String (0.0), comment=identificatie.lokaalID: Unieke identificatiecode binnen een registratie.
tijdstipRegistratie: DateTime, comment=Tijdstip waarop deze instantie van het object is opgenomen door de bronhouder.
eindRegistratie: DateTime, comment=Eind van de periode waarop deze instantie van het object geldig is bij de bronhouder. Wanneer deze waarde niet is ingevuld is de instantie nog geldig.
LV-publicatiedatum: DateTime, comment=Tijdstip waarop deze instantie van het object is opgenomen in de landelijke voorziening.
bronhouder: String (0.0), comment=De bronhoudercode van het object.
inOnderzoek: Integer(Boolean) (0.0), comment=Een aanduiding waarmee wordt aangegeven dat een onderzoek wordt uitgevoerd naar de juistheid van een of meer gegevens van het betreffende object.
relatieveHoogteligging: Integer (0.0), comment=Aanduiding voor de relatieve hoogte van het object
bgt-status: String (0.0), comment=De status gekoppeld aan de levenscyclus van een geo-object
plus-status: String (0.0), comment=De status gekoppeld aan de levenscyclus van een geo-object, indien dit een uitbreiding van de populatie betreft.
identificatieBAGPND: String (0.0), comment=De unieke identificatie van het object zoals is toegekend in de BAG-administratie.
