### PR TITLE
Fix dagster deprecation warnings

### DIFF
--- a/docs/development/code.md
+++ b/docs/development/code.md
@@ -168,6 +168,40 @@ For running all tests, you can run:
 make test_all
 ```
 
+### Analyzing Test Results
+
+After running tests, you can analyze the warnings and errors with the test log parser:
+
+```shell
+make test_report
+```
+
+This command parses `tests/test.log` and displays a summary of unique warnings and errors, grouped by type and sorted by frequency. This is useful for identifying systematic issues across test runs.
+
+**Example output:**
+
+```
+=== Test Log Analysis: tests/test.log ===
+
+WARNINGS (8 unique):
+──────────────────────────────────────────────────
+[146 occurrences] PydanticDeprecatedSince20
+  Location: .../dagster/_model/pydantic_compat_layer.py:70
+  Message: The `__fields__` attribute is deprecated, use the `model_fields` class property instead...
+
+[10 occurrences] DeprecationWarning
+  Location: .../dagster/_utils/__init__.py:691
+  Message: Function `DagsterInstance.get_event_records` is deprecated and will be removed in 2.0.
+
+Summary: 8 unique warnings
+```
+
+For more options, see `scripts/README.md` or run:
+
+```shell
+python3 scripts/parse_test_log.py --help
+```
+
 ## Installing requirements without the Docker setup
 
 The pipeline has the following requirements:

--- a/makefile
+++ b/makefile
@@ -113,6 +113,9 @@ test_all:
 	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-floors-estimation pytest /opt/3dbag-pipeline/packages/floors_estimation/tests/ -v --run-slow --run-all 2>&1 | tee -a tests/test.log || FAILED=1; \
     exit $$FAILED
 
+test_report:
+	python3 scripts/parse_test_log.py
+
 include .env
 
 download:

--- a/makefile
+++ b/makefile
@@ -68,44 +68,49 @@ docker_down_rm:
 	docker compose -p $(COMPOSE_PROJECT_NAME) down --volumes --remove-orphans --rmi local
 
 test:
-	@set -e; \
+	@set -e; set -o pipefail; \
+	rm -f tests/test.log; \
 	FAILED=0; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/common/tests/ -v || FAILED=1; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/ -v || FAILED=1; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-party-walls pytest /opt/3dbag-pipeline/packages/party_walls/tests/ -v || FAILED=1; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-floors-estimation pytest /opt/3dbag-pipeline/packages/floors_estimation/tests/ -v || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/common/tests/ -v 2>&1 | tee -a tests/test.log || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/ -v 2>&1 | tee -a tests/test.log || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-party-walls pytest /opt/3dbag-pipeline/packages/party_walls/tests/ -v 2>&1 | tee -a tests/test.log || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-floors-estimation pytest /opt/3dbag-pipeline/packages/floors_estimation/tests/ -v 2>&1 | tee -a tests/test.log || FAILED=1; \
 	exit $$FAILED
 
 test_slow:
-	@set -e; \
+	@set -e; set -o pipefail; \
+	rm -f tests/test.log; \
 	FAILED=0; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/common/tests/ -v --run-slow || FAILED=1; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/ -v --run-slow || FAILED=1; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-party-walls pytest /opt/3dbag-pipeline/packages/party_walls/tests/ -v --run-slow || FAILED=1; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-floors-estimation pytest /opt/3dbag-pipeline/packages/floors_estimation/tests/ -v --run-slow || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/common/tests/ -v --run-slow 2>&1 | tee -a tests/test.log || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/ -v --run-slow 2>&1 | tee -a tests/test.log || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-party-walls pytest /opt/3dbag-pipeline/packages/party_walls/tests/ -v --run-slow 2>&1 | tee -a tests/test.log || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-floors-estimation pytest /opt/3dbag-pipeline/packages/floors_estimation/tests/ -v --run-slow 2>&1 | tee -a tests/test.log || FAILED=1; \
     exit $$FAILED
 
 test_integration:
-	@set -e; \
+	@set -e; set -o pipefail; \
+	rm -f tests/test.log; \
 	FAILED=0; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/test_integration.py -v -s --run-all || FAILED=1; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-party-walls pytest /opt/3dbag-pipeline/packages/party_walls/tests/test_integration.py -v -s --run-all || FAILED=1; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-floors-estimation pytest /opt/3dbag-pipeline/packages/floors_estimation/tests/test_integration.py -v -s --run-all || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/test_integration.py -v -s --run-all 2>&1 | tee -a tests/test.log || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-party-walls pytest /opt/3dbag-pipeline/packages/party_walls/tests/test_integration.py -v -s --run-all 2>&1 | tee -a tests/test.log || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-floors-estimation pytest /opt/3dbag-pipeline/packages/floors_estimation/tests/test_integration.py -v -s --run-all 2>&1 | tee -a tests/test.log || FAILED=1; \
     exit $$FAILED
 
 test_deploy:
-	@set -e; \
+	@set -e; set -o pipefail; \
+	rm -f tests/test.log; \
 	FAILED=0; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/test_integration.py -v -s --run-all --run-deploy -k 'test_integration_deploy_release' || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/test_integration.py -v -s --run-all --run-deploy -k 'test_integration_deploy_release' 2>&1 | tee -a tests/test.log || FAILED=1; \
     exit $$FAILED
 
 test_all:
-	@set -e; \
+	@set -e; set -o pipefail; \
+	rm -f tests/test.log; \
 	FAILED=0; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/common/tests/ -v --run-slow --run-all || FAILED=1; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/ -v --run-slow  --run-all || FAILED=1; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-party-walls pytest /opt/3dbag-pipeline/packages/party_walls/tests/ -v --run-slow --run-all || FAILED=1; \
-	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-floors-estimation pytest /opt/3dbag-pipeline/packages/floors_estimation/tests/ -v --run-slow --run-all || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/common/tests/ -v --run-slow --run-all 2>&1 | tee -a tests/test.log || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/ -v --run-slow  --run-all 2>&1 | tee -a tests/test.log || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-party-walls pytest /opt/3dbag-pipeline/packages/party_walls/tests/ -v --run-slow --run-all 2>&1 | tee -a tests/test.log || FAILED=1; \
+	docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-floors-estimation pytest /opt/3dbag-pipeline/packages/floors_estimation/tests/ -v --run-slow --run-all 2>&1 | tee -a tests/test.log || FAILED=1; \
     exit $$FAILED
 
 include .env

--- a/makefile
+++ b/makefile
@@ -1,3 +1,6 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -ec
+
 include docker/.env
 
 export COMPOSE_PROJECT_NAME := $(if $(COMPOSE_PROJECT_NAME),$(COMPOSE_PROJECT_NAME),bag3d-dev)

--- a/packages/core/src/bag3d/core/assets/ahn/metadata.py
+++ b/packages/core/src/bag3d/core/assets/ahn/metadata.py
@@ -202,7 +202,7 @@ def compute_load_metadata(
     tile_id = context.partition_key
     conn = context.resources.db_connection.connect
     if not laz_files_ahn.new:
-        if not context.op_execution_context.op_execution_context.op_config["force"]:
+        if not context.op_execution_context.op_config["force"]:
             logger.info(
                 f"Metadata for this LAZ tile {tile_id} already exists, "
                 f"skipping computation."

--- a/packages/core/src/bag3d/core/assets/export/metadata.py
+++ b/packages/core/src/bag3d/core/assets/export/metadata.py
@@ -233,7 +233,9 @@ def metadata(context: AssetExecutionContext):
                     "name": ".".join(asset_key.path),
                     "runId": event_record.run_id,
                     "featureCount": rows.value if rows is not None else None,
-                    "dateTime": datetime.fromtimestamp(event_record.event_log_entry.timestamp)
+                    "dateTime": datetime.fromtimestamp(
+                        event_record.event_log_entry.timestamp
+                    )
                     .date()
                     .isoformat(),
                     "dataVersion": event_record.asset_materialization.tags[

--- a/packages/core/src/bag3d/core/assets/export/metadata.py
+++ b/packages/core/src/bag3d/core/assets/export/metadata.py
@@ -11,8 +11,7 @@ from dagster import (
     Output,
     asset,
     AssetExecutionContext,
-    DagsterEventType,
-    EventRecordsFilter,
+    AssetRecordsFilter,
 )
 from psycopg.sql import SQL
 
@@ -217,9 +216,8 @@ def metadata(context: AssetExecutionContext):
     # is has succeeded.
     process_step_list = []
     for asset_key in asset_keys:
-        event_record_list = instance.get_event_records(
-            event_records_filter=EventRecordsFilter(
-                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+        event_record_list = instance.fetch_materializations(
+            records_filter=AssetRecordsFilter(
                 asset_key=asset_key,
             ),
             limit=1,

--- a/packages/core/src/bag3d/core/assets/export/metadata.py
+++ b/packages/core/src/bag3d/core/assets/export/metadata.py
@@ -221,7 +221,7 @@ def metadata(context: AssetExecutionContext):
                 asset_key=asset_key,
             ),
             limit=1,
-        )
+        ).records
         if len(event_record_list) > 0:
             event_record = event_record_list[0]
 
@@ -233,7 +233,7 @@ def metadata(context: AssetExecutionContext):
                     "name": ".".join(asset_key.path),
                     "runId": event_record.run_id,
                     "featureCount": rows.value if rows is not None else None,
-                    "dateTime": datetime.fromtimestamp(event_record.timestamp)
+                    "dateTime": datetime.fromtimestamp(event_record.event_log_entry.timestamp)
                     .date()
                     .isoformat(),
                     "dataVersion": event_record.asset_materialization.tags[

--- a/packages/core/src/bag3d/core/assets/reconstruction/reconstruction.py
+++ b/packages/core/src/bag3d/core/assets/reconstruction/reconstruction.py
@@ -119,7 +119,7 @@ def reconstructed_building_models_nl(
 
     try:
         result = context.resources.roofer.runner.run(
-            f"{{exe}} --config {{local_path}} {output_dir} -j {context.op_config['concurrency']} --loglevel {context.op_config['loglevel']} --skip-pc-check",
+            f"{{exe}} --config {{local_path}} {output_dir} -j {context.op_execution_context.op_config['concurrency']} --loglevel {context.op_execution_context.op_config['loglevel']} --skip-pc-check",
             exe_name="roofer",
             local_path=roofer_toml,
             context=context,

--- a/packages/core/tests/conftest.py
+++ b/packages/core/tests/conftest.py
@@ -16,7 +16,7 @@ from bag3d.common.resources.server_transfer import ServerTransferResource
 from bag3d.common.resources.files import FileStoreResource
 from bag3d.common.types import PostgresTableIdentifier
 from bag3d.core.assets.input import RECONSTRUCTION_INPUT_SCHEMA
-from dagster import AssetKey, asset, build_op_context
+from dagster import AssetKey, AssetSpec, IOManager, io_manager, build_op_context
 
 LOCAL_DIR = os.getenv("BAG3D_TEST_DATA")
 HOST = os.getenv("BAG3D_PG_HOST")
@@ -24,6 +24,32 @@ PORT = os.getenv("BAG3D_PG_PORT")
 USER = os.getenv("BAG3D_PG_USER")
 PASSWORD = os.getenv("BAG3D_PG_PASSWORD")
 DB_NAME = os.getenv("BAG3D_PG_DATABASE")
+
+
+class MockAssetIOManager(IOManager):
+    """IO manager that returns pre-configured values for mock assets."""
+
+    def __init__(self, values: dict):
+        self._values = values
+
+    def load_input(self, context):
+        key = tuple(context.asset_key.path)
+        if key not in self._values:
+            raise KeyError(f"No mock value configured for asset {key}")
+        return self._values[key]
+
+    def handle_output(self, context, obj):
+        # No-op for mock assets - they don't produce outputs
+        pass
+
+
+@io_manager
+def mock_asset_io_manager(init_context):
+    """Factory for creating mock IO managers with configured values."""
+    values = init_context.resource_config.get("values", {})
+    # Convert string keys back to tuples
+    values = {tuple(k.split("/")): v for k, v in values.items()}
+    return MockAssetIOManager(values)
 
 
 @pytest.fixture(scope="session")
@@ -362,203 +388,200 @@ def tile_index_ahn_fix():
 
 @pytest.fixture(scope="session")
 def mock_asset_reconstruction_input():
-    @asset(key_prefix=["input"])
-    def reconstruction_input():
-        return PostgresTableIdentifier(
-            RECONSTRUCTION_INPUT_SCHEMA, "reconstruction_input"
-        )
-
-    return reconstruction_input
+    return AssetSpec(
+        key=AssetKey(["input", "reconstruction_input"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
+    )
 
 
 @pytest.fixture(scope="session")
 def mock_asset_tiles():
-    @asset(key_prefix=["input"])
-    def tiles():
-        return PostgresTableIdentifier(RECONSTRUCTION_INPUT_SCHEMA, "tiles")
-
-    return tiles
+    return AssetSpec(
+        key=AssetKey(["input", "tiles"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
+    )
 
 
 @pytest.fixture(scope="session")
 def mock_asset_index():
-    @asset(key_prefix=["input"])
-    def index():
-        return PostgresTableIdentifier(RECONSTRUCTION_INPUT_SCHEMA, "index")
-
-    return index
+    return AssetSpec(
+        key=AssetKey(["input", "index"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
+    )
 
 
 @pytest.fixture(scope="session")
 def mock_asset_metadata_ahn3_index():
-    @asset(key_prefix=["ahn"])
-    def metadata_ahn3_index():
-        return PostgresTableIdentifier("ahn", "metadata_ahn3")
-
-    return metadata_ahn3_index
+    return AssetSpec(
+        key=AssetKey(["ahn", "metadata_ahn3_index"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
+    )
 
 
 @pytest.fixture(scope="session")
 def mock_asset_metadata_ahn4_index():
-    @asset(key_prefix=["ahn"])
-    def metadata_ahn4_index():
-        return PostgresTableIdentifier("ahn", "metadata_ahn4")
-
-    return metadata_ahn4_index
+    return AssetSpec(
+        key=AssetKey(["ahn", "metadata_ahn4_index"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
+    )
 
 
 @pytest.fixture(scope="session")
 def mock_asset_metadata_ahn5_index():
-    @asset(key_prefix=["ahn"])
-    def metadata_ahn5_index():
-        return PostgresTableIdentifier("ahn", "metadata_ahn5")
-
-    return metadata_ahn5_index
+    return AssetSpec(
+        key=AssetKey(["ahn", "metadata_ahn5_index"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
+    )
 
 
 @pytest.fixture(scope="session")
 def mock_asset_compressed_tiles():
-    @asset(key_prefix=["export"])
-    def compressed_tiles():
-        return None
-
-    return compressed_tiles
+    return AssetSpec(
+        key=AssetKey(["export", "compressed_tiles"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
+    )
 
 
 @pytest.fixture(scope="session")
 def mock_asset_compressed_tiles_validation(test_data_dir):
-    path = (
-        test_data_dir
-        / "integration_deploy_release"
-        / "3DBAG"
-        / "export_test_version"
-        / "validate_compressed_files.csv"
+    return AssetSpec(
+        key=AssetKey(["export", "compressed_tiles_validation"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
     )
-
-    @asset(key_prefix=["export"])
-    def compressed_tiles_validation():
-        return path
-
-    return compressed_tiles_validation
 
 
 @pytest.fixture(scope="session")
 def mock_asset_export_index(test_data_dir):
-    path = (
-        test_data_dir
-        / "integration_deploy_release"
-        / "3DBAG"
-        / "export_test_version"
-        / "export_index.csv"
+    return AssetSpec(
+        key=AssetKey(["export", "export_index"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
     )
-
-    @asset(key_prefix=["export"])
-    def export_index():
-        return path
-
-    return export_index
 
 
 @pytest.fixture(scope="session")
 def mock_asset_geopackage_nl(test_data_dir):
-    path = (
-        test_data_dir
-        / "integration_deploy_release"
-        / "3DBAG"
-        / "export_test_version"
-        / "3dbag_nl.gpkg.zip"
+    return AssetSpec(
+        key=AssetKey(["export", "geopackage_nl"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
     )
-
-    @asset(key_prefix=["export"])
-    def geopackage_nl():
-        return path
-
-    return geopackage_nl
 
 
 @pytest.fixture(scope="session")
 def mock_asset_metadata(test_data_dir):
-    path = (
-        test_data_dir
-        / "integration_deploy_release"
-        / "3DBAG"
-        / "export_test_version"
-        / "metadata.json"
+    return AssetSpec(
+        key=AssetKey(["export", "metadata"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
     )
-
-    @asset(key_prefix=["export"])
-    def metadata():
-        return path
-
-    return metadata
 
 
 @pytest.fixture(scope="session")
 def mock_asset_reconstruction_output_3dtiles_lod12_nl(test_data_dir):
-    path = (
-        test_data_dir
-        / "integration_deploy_release"
-        / "3DBAG"
-        / "export_test_version"
-        / "cesium3dtiles"
-        / "lod12"
+    return AssetSpec(
+        key=AssetKey(["export", "reconstruction_output_3dtiles_lod12_nl"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
     )
-
-    @asset(key_prefix=["export"])
-    def reconstruction_output_3dtiles_lod12_nl():
-        return path
-
-    return reconstruction_output_3dtiles_lod12_nl
 
 
 @pytest.fixture(scope="session")
 def mock_asset_reconstruction_output_3dtiles_lod13_nl(test_data_dir):
-    path = (
-        test_data_dir
-        / "integration_deploy_release"
-        / "3DBAG"
-        / "export_test_version"
-        / "cesium3dtiles"
-        / "lod13"
+    return AssetSpec(
+        key=AssetKey(["export", "reconstruction_output_3dtiles_lod13_nl"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
     )
-
-    @asset(key_prefix=["export"])
-    def reconstruction_output_3dtiles_lod13_nl():
-        return path
-
-    return reconstruction_output_3dtiles_lod13_nl
 
 
 @pytest.fixture(scope="session")
 def mock_asset_reconstruction_output_3dtiles_lod22_nl(test_data_dir):
-    path = (
-        test_data_dir
-        / "integration_deploy_release"
-        / "3DBAG"
-        / "export_test_version"
-        / "cesium3dtiles"
-        / "lod22"
+    return AssetSpec(
+        key=AssetKey(["export", "reconstruction_output_3dtiles_lod22_nl"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
     )
-
-    @asset(key_prefix=["export"])
-    def reconstruction_output_3dtiles_lod22_nl():
-        return path
-
-    return reconstruction_output_3dtiles_lod22_nl
 
 
 @pytest.fixture(scope="session")
 def mock_asset_reconstruction_output_multitiles_nl(test_data_dir):
-    path = (
-        test_data_dir
-        / "integration_deploy_release"
-        / "3DBAG"
-        / "export_test_version"
-        / "tiles"
+    return AssetSpec(
+        key=AssetKey(["export", "reconstruction_output_multitiles_nl"]),
+        metadata={"dagster/io_manager_key": "mock_asset_io_manager"},
     )
 
-    @asset(key_prefix=["export"])
-    def reconstruction_output_multitiles_nl():
-        return path
 
-    return reconstruction_output_multitiles_nl
+@pytest.fixture(scope="session")
+def mock_asset_values(test_data_dir):
+    """Values to be returned by the mock IO manager for each asset key."""
+    return {
+        "input/reconstruction_input": PostgresTableIdentifier(
+            RECONSTRUCTION_INPUT_SCHEMA, "reconstruction_input"
+        ),
+        "input/tiles": PostgresTableIdentifier(RECONSTRUCTION_INPUT_SCHEMA, "tiles"),
+        "input/index": PostgresTableIdentifier(RECONSTRUCTION_INPUT_SCHEMA, "index"),
+        "ahn/metadata_ahn3_index": PostgresTableIdentifier("ahn", "metadata_ahn3"),
+        "ahn/metadata_ahn4_index": PostgresTableIdentifier("ahn", "metadata_ahn4"),
+        "ahn/metadata_ahn5_index": PostgresTableIdentifier("ahn", "metadata_ahn5"),
+        "export/compressed_tiles": None,
+        "export/compressed_tiles_validation": (
+            test_data_dir
+            / "integration_deploy_release"
+            / "3DBAG"
+            / "export_test_version"
+            / "validate_compressed_files.csv"
+        ),
+        "export/export_index": (
+            test_data_dir
+            / "integration_deploy_release"
+            / "3DBAG"
+            / "export_test_version"
+            / "export_index.csv"
+        ),
+        "export/geopackage_nl": (
+            test_data_dir
+            / "integration_deploy_release"
+            / "3DBAG"
+            / "export_test_version"
+            / "3dbag_nl.gpkg.zip"
+        ),
+        "export/metadata": (
+            test_data_dir
+            / "integration_deploy_release"
+            / "3DBAG"
+            / "export_test_version"
+            / "metadata.json"
+        ),
+        "export/reconstruction_output_3dtiles_lod12_nl": (
+            test_data_dir
+            / "integration_deploy_release"
+            / "3DBAG"
+            / "export_test_version"
+            / "cesium3dtiles"
+            / "lod12"
+        ),
+        "export/reconstruction_output_3dtiles_lod13_nl": (
+            test_data_dir
+            / "integration_deploy_release"
+            / "3DBAG"
+            / "export_test_version"
+            / "cesium3dtiles"
+            / "lod13"
+        ),
+        "export/reconstruction_output_3dtiles_lod22_nl": (
+            test_data_dir
+            / "integration_deploy_release"
+            / "3DBAG"
+            / "export_test_version"
+            / "cesium3dtiles"
+            / "lod22"
+        ),
+        "export/reconstruction_output_multitiles_nl": (
+            test_data_dir
+            / "integration_deploy_release"
+            / "3DBAG"
+            / "export_test_version"
+            / "tiles"
+        ),
+    }
+
+
+@pytest.fixture(scope="session")
+def configured_mock_asset_io_manager(mock_asset_values):
+    """Configured IO manager resource with pre-set values for mock assets."""
+    return mock_asset_io_manager.configured({"values": mock_asset_values})

--- a/packages/core/tests/conftest.py
+++ b/packages/core/tests/conftest.py
@@ -16,7 +16,7 @@ from bag3d.common.resources.server_transfer import ServerTransferResource
 from bag3d.common.resources.files import FileStoreResource
 from bag3d.common.types import PostgresTableIdentifier
 from bag3d.core.assets.input import RECONSTRUCTION_INPUT_SCHEMA
-from dagster import AssetKey, IOManager, SourceAsset, build_op_context
+from dagster import AssetKey, asset, build_op_context
 
 LOCAL_DIR = os.getenv("BAG3D_TEST_DATA")
 HOST = os.getenv("BAG3D_PG_HOST")
@@ -362,283 +362,203 @@ def tile_index_ahn_fix():
 
 @pytest.fixture(scope="session")
 def mock_asset_reconstruction_input():
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            new_table = PostgresTableIdentifier(
-                RECONSTRUCTION_INPUT_SCHEMA, "reconstruction_input"
-            )
-            return new_table
+    @asset(key_prefix=["input"])
+    def reconstruction_input():
+        return PostgresTableIdentifier(
+            RECONSTRUCTION_INPUT_SCHEMA, "reconstruction_input"
+        )
 
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["input", "reconstruction_input"]),
-        io_manager_def=MockIOManager(),
-    )
+    return reconstruction_input
 
 
 @pytest.fixture(scope="session")
 def mock_asset_tiles():
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            new_table = PostgresTableIdentifier(RECONSTRUCTION_INPUT_SCHEMA, "tiles")
-            return new_table
+    @asset(key_prefix=["input"])
+    def tiles():
+        return PostgresTableIdentifier(RECONSTRUCTION_INPUT_SCHEMA, "tiles")
 
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["input", "tiles"]),
-        io_manager_def=MockIOManager(),
-    )
+    return tiles
 
 
 @pytest.fixture(scope="session")
 def mock_asset_index():
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            new_table = PostgresTableIdentifier(RECONSTRUCTION_INPUT_SCHEMA, "index")
-            return new_table
+    @asset(key_prefix=["input"])
+    def index():
+        return PostgresTableIdentifier(RECONSTRUCTION_INPUT_SCHEMA, "index")
 
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["input", "index"]),
-        io_manager_def=MockIOManager(),
-    )
+    return index
 
 
 @pytest.fixture(scope="session")
 def mock_asset_metadata_ahn3_index():
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            new_table = PostgresTableIdentifier("ahn", "metadata_ahn3")
-            return new_table
+    @asset(key_prefix=["ahn"])
+    def metadata_ahn3_index():
+        return PostgresTableIdentifier("ahn", "metadata_ahn3")
 
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["ahn", "metadata_ahn3_index"]),
-        io_manager_def=MockIOManager(),
-    )
+    return metadata_ahn3_index
 
 
 @pytest.fixture(scope="session")
 def mock_asset_metadata_ahn4_index():
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            new_table = PostgresTableIdentifier("ahn", "metadata_ahn4")
-            return new_table
+    @asset(key_prefix=["ahn"])
+    def metadata_ahn4_index():
+        return PostgresTableIdentifier("ahn", "metadata_ahn4")
 
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["ahn", "metadata_ahn4_index"]),
-        io_manager_def=MockIOManager(),
-    )
+    return metadata_ahn4_index
 
 
 @pytest.fixture(scope="session")
 def mock_asset_metadata_ahn5_index():
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            new_table = PostgresTableIdentifier("ahn", "metadata_ahn5")
-            return new_table
+    @asset(key_prefix=["ahn"])
+    def metadata_ahn5_index():
+        return PostgresTableIdentifier("ahn", "metadata_ahn5")
 
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["ahn", "metadata_ahn5_index"]),
-        io_manager_def=MockIOManager(),
-    )
+    return metadata_ahn5_index
 
 
 @pytest.fixture(scope="session")
 def mock_asset_compressed_tiles():
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            return None
+    @asset(key_prefix=["export"])
+    def compressed_tiles():
+        return None
 
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["export", "compressed_tiles"]),
-        io_manager_def=MockIOManager(),
-    )
+    return compressed_tiles
 
 
 @pytest.fixture(scope="session")
 def mock_asset_compressed_tiles_validation(test_data_dir):
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            return (
-                test_data_dir
-                / "integration_deploy_release"
-                / "3DBAG"
-                / "export_test_version"
-                / "validate_compressed_files.csv"
-            )
-
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["export", "compressed_tiles_validation"]),
-        io_manager_def=MockIOManager(),
+    path = (
+        test_data_dir
+        / "integration_deploy_release"
+        / "3DBAG"
+        / "export_test_version"
+        / "validate_compressed_files.csv"
     )
+
+    @asset(key_prefix=["export"])
+    def compressed_tiles_validation():
+        return path
+
+    return compressed_tiles_validation
 
 
 @pytest.fixture(scope="session")
 def mock_asset_export_index(test_data_dir):
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            return (
-                test_data_dir
-                / "integration_deploy_release"
-                / "3DBAG"
-                / "export_test_version"
-                / "export_index.csv"
-            )
-
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["export", "export_index"]),
-        io_manager_def=MockIOManager(),
+    path = (
+        test_data_dir
+        / "integration_deploy_release"
+        / "3DBAG"
+        / "export_test_version"
+        / "export_index.csv"
     )
+
+    @asset(key_prefix=["export"])
+    def export_index():
+        return path
+
+    return export_index
 
 
 @pytest.fixture(scope="session")
 def mock_asset_geopackage_nl(test_data_dir):
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            return (
-                test_data_dir
-                / "integration_deploy_release"
-                / "3DBAG"
-                / "export_test_version"
-                / "3dbag_nl.gpkg.zip"
-            )
-
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["export", "geopackage_nl"]),
-        io_manager_def=MockIOManager(),
+    path = (
+        test_data_dir
+        / "integration_deploy_release"
+        / "3DBAG"
+        / "export_test_version"
+        / "3dbag_nl.gpkg.zip"
     )
+
+    @asset(key_prefix=["export"])
+    def geopackage_nl():
+        return path
+
+    return geopackage_nl
 
 
 @pytest.fixture(scope="session")
 def mock_asset_metadata(test_data_dir):
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            return (
-                test_data_dir
-                / "integration_deploy_release"
-                / "3DBAG"
-                / "export_test_version"
-                / "metadata.json"
-            )
-
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["export", "metadata"]),
-        io_manager_def=MockIOManager(),
+    path = (
+        test_data_dir
+        / "integration_deploy_release"
+        / "3DBAG"
+        / "export_test_version"
+        / "metadata.json"
     )
+
+    @asset(key_prefix=["export"])
+    def metadata():
+        return path
+
+    return metadata
 
 
 @pytest.fixture(scope="session")
 def mock_asset_reconstruction_output_3dtiles_lod12_nl(test_data_dir):
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            return (
-                test_data_dir
-                / "integration_deploy_release"
-                / "3DBAG"
-                / "export_test_version"
-                / "cesium3dtiles"
-                / "lod12"
-            )
-
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["export", "reconstruction_output_3dtiles_lod12_nl"]),
-        io_manager_def=MockIOManager(),
+    path = (
+        test_data_dir
+        / "integration_deploy_release"
+        / "3DBAG"
+        / "export_test_version"
+        / "cesium3dtiles"
+        / "lod12"
     )
+
+    @asset(key_prefix=["export"])
+    def reconstruction_output_3dtiles_lod12_nl():
+        return path
+
+    return reconstruction_output_3dtiles_lod12_nl
 
 
 @pytest.fixture(scope="session")
 def mock_asset_reconstruction_output_3dtiles_lod13_nl(test_data_dir):
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            return (
-                test_data_dir
-                / "integration_deploy_release"
-                / "3DBAG"
-                / "export_test_version"
-                / "cesium3dtiles"
-                / "lod13"
-            )
-
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["export", "reconstruction_output_3dtiles_lod13_nl"]),
-        io_manager_def=MockIOManager(),
+    path = (
+        test_data_dir
+        / "integration_deploy_release"
+        / "3DBAG"
+        / "export_test_version"
+        / "cesium3dtiles"
+        / "lod13"
     )
+
+    @asset(key_prefix=["export"])
+    def reconstruction_output_3dtiles_lod13_nl():
+        return path
+
+    return reconstruction_output_3dtiles_lod13_nl
 
 
 @pytest.fixture(scope="session")
 def mock_asset_reconstruction_output_3dtiles_lod22_nl(test_data_dir):
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            return (
-                test_data_dir
-                / "integration_deploy_release"
-                / "3DBAG"
-                / "export_test_version"
-                / "cesium3dtiles"
-                / "lod22"
-            )
-
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["export", "reconstruction_output_3dtiles_lod22_nl"]),
-        io_manager_def=MockIOManager(),
+    path = (
+        test_data_dir
+        / "integration_deploy_release"
+        / "3DBAG"
+        / "export_test_version"
+        / "cesium3dtiles"
+        / "lod22"
     )
+
+    @asset(key_prefix=["export"])
+    def reconstruction_output_3dtiles_lod22_nl():
+        return path
+
+    return reconstruction_output_3dtiles_lod22_nl
 
 
 @pytest.fixture(scope="session")
 def mock_asset_reconstruction_output_multitiles_nl(test_data_dir):
-    class MockIOManager(IOManager):
-        def load_input(self, context):
-            return (
-                test_data_dir
-                / "integration_deploy_release"
-                / "3DBAG"
-                / "export_test_version"
-                / "tiles"
-            )
-
-        def handle_output(self, context, obj):  # pragma: no cover
-            raise NotImplementedError()
-
-    return SourceAsset(
-        key=AssetKey(["export", "reconstruction_output_multitiles_nl"]),
-        io_manager_def=MockIOManager(),
+    path = (
+        test_data_dir
+        / "integration_deploy_release"
+        / "3DBAG"
+        / "export_test_version"
+        / "tiles"
     )
+
+    @asset(key_prefix=["export"])
+    def reconstruction_output_multitiles_nl():
+        return path
+
+    return reconstruction_output_multitiles_nl

--- a/packages/core/tests/test_integration.py
+++ b/packages/core/tests/test_integration.py
@@ -115,6 +115,7 @@ def test_integration_reconstruction_and_export(
     mock_asset_metadata_ahn3_index,
     mock_asset_metadata_ahn4_index,
     mock_asset_metadata_ahn5_index,
+    configured_mock_asset_io_manager,
 ):
     # update quadtree
     og_quadtree = test_data_dir / "quadtree.tsv"
@@ -151,6 +152,7 @@ def test_integration_reconstruction_and_export(
             exe_cjio=os.getenv("EXE_PATH_CJIO"),
         ),
         "specs": Specs3DBAGResource(),
+        "mock_asset_io_manager": configured_mock_asset_io_manager,
     }
 
     all_reconstruction_assets = load_assets_from_package_module(
@@ -237,6 +239,7 @@ def test_integration_deploy_release(
     mock_asset_reconstruction_output_3dtiles_lod13_nl,
     mock_asset_reconstruction_output_3dtiles_lod22_nl,
     mock_asset_reconstruction_output_multitiles_nl,
+    configured_mock_asset_io_manager,
 ):
     """Can we deploy and release the 3DBAG, everything included?"""
 
@@ -245,6 +248,7 @@ def test_integration_deploy_release(
         "godzilla_server": godzilla_server,
         "podzilla_server": podzilla_server,
         "db_connection": database,
+        "mock_asset_io_manager": configured_mock_asset_io_manager,
     }
 
     all_deploy_assets = load_assets_from_package_module(

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,9 @@ Scripts for ad-hoc operations and analysis.
 
 ## Available Scripts
 
-### parse_test_log.py
+### Test Analysis
+
+#### parse_test_log.py
 
 Parses pytest output from `tests/test.log` and extracts unique warnings and errors, presenting them in an organized, readable format with occurrence counts and file locations.
 
@@ -28,14 +30,303 @@ For convenience, you can also use the `make` target after running tests:
 
 ```bash
 make test              # Run all tests and save to tests/test.log
-make test_report       # Analyze warnings from the test run
+make test_report       # Analyze warnings and errors from the test run
 ```
 
 **Features:**
 
+- Extracts both errors and warnings from test runs
 - Aggregates warnings across multiple test sessions
 - Deduplicates warnings by type and message content
 - Sorts by frequency (most common warnings first)
+- Shows test name and error type for failures
 - Shows file location and full warning message for each unique warning
 - Color-coded terminal output (disable with `--no-color`)
 - Graceful handling of edge cases (missing files, empty logs, no warnings)
+
+---
+
+### Dagster Code Location Management
+
+#### monitor-code-location.py
+
+Checks if a Dagster code location has loaded successfully by querying the Dagster GraphQL API.
+
+**Usage:**
+
+```bash
+# Check the default 'core' code location on localhost:3000
+python3 scripts/monitor-code-location.py
+
+# Check a specific code location
+python3 scripts/monitor-code-location.py --code-location floors_estimation
+
+# Check a remote Dagster instance
+python3 scripts/monitor-code-location.py --host dagster.example.com --port 3000 --code-location core
+```
+
+**Options:**
+
+- `--host` - Dagster host (default: `localhost`)
+- `--port` - Dagster port (default: `3000`)
+- `--code-location` - Code location name (default: `core`)
+
+**Exit codes:**
+
+- `0` - Code location loaded successfully
+- `1` - Code location failed to load
+
+**Use cases:**
+
+- Health checks in monitoring/CI pipelines
+- Verifying code location status after deployments
+- Automated validation that all code locations are operational
+
+#### reload-code-location.py
+
+Reloads a Dagster code location without restarting the Dagster daemon. Useful for applying code changes without full system restarts.
+
+**Usage:**
+
+```bash
+# Reload the default 'core' code location
+python3 scripts/reload-code-location.py
+
+# Reload a specific code location
+python3 scripts/reload-code-location.py --code-location party_walls
+
+# Reload on a remote Dagster instance
+python3 scripts/reload-code-location.py --host dagster.example.com --port 3000 --code-location core
+```
+
+**Options:**
+
+- `--host` - Dagster host (default: `localhost`)
+- `--port` - Dagster port (default: `3000`)
+- `--code-location` - Code location name to reload (default: `core`)
+
+**Exit codes:**
+
+- `0` - Reload succeeded
+- `1` - Reload failed
+
+**Note:** Requires the code location to support reloading (most do, see Dagster documentation for exceptions).
+
+---
+
+### Roofer Reconstruction Analysis
+
+Tools for analyzing roofer reconstruction logs stored in Dagster.
+
+#### roofer-logs-parse.py
+
+Extracts reconstruction step timings from roofer logs recorded by Dagster. Parses `[reconstructor t]` timing records and exports them to CSV for analysis.
+
+**Usage:**
+
+```bash
+# Extract timings from successful reconstructions
+python3 scripts/roofer-logs-parse.py \
+  --storage /opt/dagster/dagster_home/storage \
+  --output reconstruction-times.csv
+
+# Query from a remote Dagster instance
+python3 scripts/roofer-logs-parse.py \
+  --host dagster.example.com \
+  --port 3000 \
+  --storage /dagster/storage \
+  --output results.csv
+```
+
+**Options:**
+
+- `--host` - Dagster host (default: `localhost`)
+- `--port` - Dagster port (default: `3000`)
+- `--storage` - Path to Dagster storage location (required)
+- `--output` / `-o` - Output CSV file path (required)
+
+**Output CSV columns:**
+
+The generated CSV includes timing data from roofer reconstruction runs, useful for performance analysis and optimization.
+
+**Workflow:**
+
+1. Queries Dagster for successful reconstruction runs
+2. Retrieves stored logs from Dagster storage
+3. Parses timing records from roofer logs
+4. Exports results to CSV
+
+#### roofer-logs-parse-debug.py
+
+Analyzes unfinished buildings in reconstruction by parsing Dagster debug files. Helps identify buildings that failed to complete reconstruction.
+
+**Usage:**
+
+```bash
+# Analyze debug files from a directory
+python3 scripts/roofer-logs-parse-debug.py --debug-dir ./debug_files/
+```
+
+**Setup:**
+
+1. Download debug files from Dagster UI:
+   - Go to Runs overview
+   - Click the dropdown menu of the 'View' button on a run
+   - Select 'Download debug file'
+   - Download all `.gz` files into a single directory
+
+2. Run the script on that directory:
+
+```bash
+python3 scripts/roofer-logs-parse-debug.py --debug-dir /path/to/debug_files/
+```
+
+**Output:**
+
+The script prints building IDs that have a `[reconstructor] start:` record but no matching `[reconstructor] finish:` record, indicating incomplete reconstructions.
+
+**Use cases:**
+
+- Debugging failed reconstruction runs
+- Identifying which buildings need to be re-processed
+- Performance analysis and troubleshooting
+
+#### roofer-logs-plot.py
+
+Generates matplotlib visualizations of reconstruction time statistics from `reconstruction-times.csv`. Creates bar charts showing median and mean reconstruction times.
+
+**Requirements:**
+
+```bash
+pip install pandas matplotlib
+```
+
+**Usage:**
+
+```bash
+# Plot statistics (shows two plots: median and mean)
+python3 scripts/roofer-logs-plot.py
+```
+
+**Output:**
+
+- Two matplotlib windows showing:
+  - Median reconstruction times by building
+  - Mean reconstruction times by building
+- CSV file `reconstruction-times-above_10min.csv` containing buildings that took >10 minutes
+
+**Prerequisites:**
+
+- Must have `scripts/reconstruction-times.csv` generated by `roofer-logs-parse.py`
+
+---
+
+### Database Utilities
+
+#### bag_per_province.sql
+
+SQL script that creates a view associating BAG (Building Address Group) data with Dutch provinces using the 2024 administrative boundaries.
+
+**Setup:**
+
+1. Download the latest administrative units GPKG from:
+   - https://www.nationaalgeoregister.nl/geonetwork/srv/api/records/208bc283-7c66-4ce7-8ad3-1cf3e8933fb5
+   - Example: https://service.pdok.nl/kadaster/bestuurlijkegebieden/atom/v1_0/downloads/BestuurlijkeGebieden_2024.gpkg
+
+2. Load into PostgreSQL:
+
+```bash
+ogr2ogr -f PostgreSQL \
+  -nln administrative_units.provinciegebied_2024 \
+  PG:"dbname=baseregisters host=localhost port=5432 user=etl active_schema=administrative_units" \
+  BestuurlijkeGebieden_2024.gpkg \
+  provinciegebied
+```
+
+3. Execute the SQL script:
+
+```bash
+psql -d baseregisters -f scripts/bag_per_province.sql
+```
+
+**Output:**
+
+- Creates `lvbag.pandactueelbestaand_provinces` view
+- Each building is assigned to a province based on centroid containment
+- Includes `provincienaam` column with province name
+
+---
+
+### File Organization
+
+#### symlink_laz_per_province/
+
+Creates directory structure per Dutch province and symlinks LAZ (LiDAR) files based on their geographic location using province boundaries and AHN tile index from webservices.
+
+**Requirements:**
+
+```bash
+cd scripts/symlink_laz_per_province
+pip install -r requirements.txt
+```
+
+**Usage:**
+
+```bash
+python3 scripts/symlink_laz_per_province/symlink_laz_per_province.py
+```
+
+**Configuration:**
+
+Environment variables (from `.env`):
+- Database connection details for querying province boundaries
+- LAZ file locations
+
+**Output:**
+
+Creates symlinks organized by province:
+```
+output_dir/
+  Drenthe/
+    *.laz -> /original/path/file1.laz
+  Friesland/
+    *.laz -> /original/path/file2.laz
+  ...
+```
+
+**Features:**
+
+- Retrieves province boundaries from webservices
+- Uses AHN tile index to locate LAZ files
+- Creates directory per province
+- Links files based on spatial containment
+
+---
+
+### Documentation Utilities
+
+#### generate-changelog.txt
+
+Instructions and template for generating a changelog from git commits and GitHub PRs.
+
+**Process:**
+
+1. Run the commands in this file to gather data:
+
+```bash
+git log 9e01ff013c4d3b858b44fc6b4cdb0026df865d86..HEAD --pretty=format:"%h%n%s%n%b%n----" > commits_full.txt
+
+gh pr list --state all --limit 100 --json number,title,body,mergedAt,closedAt,createdAt \
+  --jq ".[] | \"#\" + (.number|tostring) + \" \" + .title + \"\n\" + .body + \"\n----\"" > prs_full.txt
+```
+
+2. Use the generated files to create a condensed changelog focusing on:
+   - Major PRs since the specified git commit
+   - Terse descriptions
+   - "Other updates" section for minor fixes, formatting, typo fixes, etc.
+
+**Use cases:**
+
+- Release notes generation
+- Changelog updates
+- Documentation of project evolution

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,1 +1,41 @@
-Scripts for ad-hoc operations.
+Scripts for ad-hoc operations and analysis.
+
+## Available Scripts
+
+### parse_test_log.py
+
+Parses pytest output from `tests/test.log` and extracts unique warnings and errors, presenting them in an organized, readable format with occurrence counts and file locations.
+
+**Usage:**
+
+```bash
+# Analyze test warnings from the default test.log file
+python3 scripts/parse_test_log.py
+
+# Disable colored output
+python3 scripts/parse_test_log.py --no-color
+
+# Analyze a custom log file
+python3 scripts/parse_test_log.py --log-file /path/to/custom.log
+
+# Get help
+python3 scripts/parse_test_log.py --help
+```
+
+**Make Target:**
+
+For convenience, you can also use the `make` target after running tests:
+
+```bash
+make test              # Run all tests and save to tests/test.log
+make test_report       # Analyze warnings from the test run
+```
+
+**Features:**
+
+- Aggregates warnings across multiple test sessions
+- Deduplicates warnings by type and message content
+- Sorts by frequency (most common warnings first)
+- Shows file location and full warning message for each unique warning
+- Color-coded terminal output (disable with `--no-color`)
+- Graceful handling of edge cases (missing files, empty logs, no warnings)

--- a/scripts/parse_test_log.py
+++ b/scripts/parse_test_log.py
@@ -1,0 +1,196 @@
+"""Parse pytest output from test.log and extract unique warnings and errors.
+
+Reads tests/test.log (or a custom log file) and extracts unique warnings and
+errors, presenting them in an organized, readable format with occurrence counts
+and file locations. Useful for identifying systematic issues across test runs.
+"""
+
+import argparse
+import re
+from collections import defaultdict
+from pathlib import Path
+
+
+def parse_warnings(log_content):
+    """Extract warnings from pytest warning summary sections.
+
+    Handles two pytest warning summary formats:
+    1. Detailed format with full message lines
+    2. Summary format with counts on location lines
+
+    Args:
+        log_content: Full log file content as string
+
+    Returns:
+        list of tuples: (warning_type, message, location, count)
+    """
+    warnings = defaultdict(lambda: {"count": 0, "location": "", "type": ""})
+
+    # Find all warnings summary sections
+    warnings_section_pattern = r"={10,} warnings summary ={10,}"
+
+    for section_match in re.finditer(warnings_section_pattern, log_content):
+        warnings_start = section_match.end()
+        # Find end of this section (next separator or Docs line)
+        separator_pattern = r"^-{2,} Docs:|^={10,}"
+        rest = log_content[warnings_start:]
+        separator_match = re.search(separator_pattern, rest, re.MULTILINE)
+
+        if separator_match:
+            warnings_end = warnings_start + separator_match.start()
+        else:
+            warnings_end = len(log_content)
+
+        warnings_text = log_content[warnings_start:warnings_end]
+
+        # Parse two formats:
+        # 1. Location with count: "venv/...:70: 4 warnings"
+        # 2. Detailed message: "  /opt/.../file.py:70: WarningType: message"
+
+        lines = warnings_text.split("\n")
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+
+            # Try format 1: location with count suffix
+            # e.g., "venv/lib/python3.12/site-packages/dagster/_model/pydantic_compat_layer.py:70: 4 warnings"
+            if (
+                ": " in line
+                and (" warning" in line.lower())
+                and not line.startswith(" ")
+                and not line.startswith("=")
+                and not line.startswith("-")
+            ):
+                # Try to extract count from the line
+                count_match = re.search(r"(\d+)\s+warning", line.lower())
+                if count_match:
+                    count = int(count_match.group(1))
+                    # Look ahead for the detailed message
+                    if i + 1 < len(lines):
+                        next_line = lines[i + 1]
+                        msg_match = re.match(
+                            r"^\s+(/\S+\.py:\d+):\s+(\w+):\s+(.+)$", next_line
+                        )
+                        if msg_match:
+                            actual_location = msg_match.group(1)
+                            warning_type = msg_match.group(2)
+                            message = msg_match.group(3)
+                            key = (warning_type, message)
+                            warnings[key]["count"] = count
+                            warnings[key]["location"] = actual_location
+                            warnings[key]["type"] = warning_type
+                            i += 2
+                            continue
+
+            # Try format 2: just detailed message line
+            # e.g., "  /opt/.../file.py:70: WarningType: message"
+            msg_match = re.match(r"^\s+(/\S+\.py:\d+):\s+(\w+):\s+(.+)$", line)
+            if msg_match:
+                location = msg_match.group(1)
+                warning_type = msg_match.group(2)
+                message = msg_match.group(3)
+                key = (warning_type, message)
+                if key not in warnings:
+                    warnings[key]["count"] = 1
+                    warnings[key]["location"] = location
+                    warnings[key]["type"] = warning_type
+                else:
+                    warnings[key]["count"] += 1
+
+            i += 1
+
+    result = []
+    for (warning_type, message), data in warnings.items():
+        result.append(
+            (
+                warning_type,
+                message,
+                data["location"],
+                data["count"],
+            )
+        )
+
+    return result
+
+
+def format_color(text, color_code):
+    """Apply ANSI color code to text."""
+    return f"\033[{color_code}m{text}\033[0m"
+
+
+def main():
+    """Parse test log and display warnings/errors."""
+    parser = argparse.ArgumentParser(
+        description="Parse pytest log and extract unique warnings and errors"
+    )
+    parser.add_argument(
+        "--log-file",
+        type=Path,
+        default=Path("tests/test.log"),
+        help="Path to test log file (default: tests/test.log)",
+    )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable colored output",
+    )
+
+    args = parser.parse_args()
+
+    if not args.log_file.exists():
+        print(f"Error: Log file not found: {args.log_file}")
+        return 1
+
+    with args.log_file.open() as f:
+        log_content = f.read()
+
+    if not log_content.strip():
+        print("No warnings or errors found (empty log file)")
+        return 0
+
+    # Parse warnings
+    warnings = parse_warnings(log_content)
+
+    if not warnings:
+        print("No warnings found in test log")
+        return 0
+
+    # Sort by count (descending)
+    warnings_sorted = sorted(warnings, key=lambda x: x[3], reverse=True)
+
+    # Format output
+    use_color = not args.no_color
+
+    if use_color:
+        header = format_color(f"=== Test Log Analysis: {args.log_file} ===", "1")
+        section_header = format_color("WARNINGS", "1;34")  # Bold blue
+        count_fmt = lambda c: format_color(f"[{c} occurrence{'s' if c > 1 else ''}]", "1")  # Bold
+        location_fmt = lambda l: format_color(l, "36")  # Cyan
+    else:
+        header = f"=== Test Log Analysis: {args.log_file} ==="
+        section_header = "WARNINGS"
+        count_fmt = lambda c: f"[{c} occurrence{'s' if c > 1 else ''}]"
+        location_fmt = lambda l: l
+
+    print(header)
+    print()
+    print(f"{section_header} ({len(warnings_sorted)} unique):")
+    print("─" * 50)
+
+    for warning_type, message, location, count in warnings_sorted:
+        print(f"{count_fmt(count)} {warning_type}")
+        print(f"  Location: {location_fmt(location)}")
+        print(f"  Message: {message}")
+        print()
+
+    # Print summary
+    summary = f"Summary: {len(warnings_sorted)} unique warnings"
+    if use_color:
+        summary = format_color(summary, "1")  # Bold
+    print(summary)
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/scripts/parse_test_log.py
+++ b/scripts/parse_test_log.py
@@ -113,6 +113,97 @@ def parse_warnings(log_content):
     return result
 
 
+def parse_errors(log_content):
+    """Extract errors from pytest FAILURES section.
+
+    Parses the FAILURES section to extract error information including
+    error type and traceback details.
+
+    Args:
+        log_content: Full log file content as string
+
+    Returns:
+        list of tuples: (test_name, error_type, error_message)
+    """
+    errors = []
+
+    # Find FAILURES section
+    failures_pattern = r"={10,} FAILURES ={10,}"
+    failures_match = re.search(failures_pattern, log_content)
+
+    if not failures_match:
+        return errors
+
+    failures_start = failures_match.end()
+    # Find end of failures section (next separator like "===")
+    rest = log_content[failures_start:]
+    end_pattern = r"^={10,}"
+    end_match = re.search(end_pattern, rest, re.MULTILINE)
+
+    if end_match:
+        failures_end = failures_start + end_match.start()
+    else:
+        failures_end = len(log_content)
+
+    failures_text = log_content[failures_start:failures_end]
+
+    # Extract individual test failures
+    # Pattern: "__ test_name __" or similar
+    test_pattern = r"^_{2,}\s+(.+?)\s+_{2,}"
+    lines = failures_text.split("\n")
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        test_match = re.match(test_pattern, line)
+
+        if test_match:
+            test_name = test_match.group(1)
+            # Look for the error line with "E" prefix
+            error_type = ""
+            error_message = ""
+
+            # Scan forward for error lines (starting with "E" followed by whitespace)
+            # Keep searching until we find a line starting with "E", hit another test,
+            # or reach end of lines
+            j = i + 1
+            while j < len(lines):
+                error_line = lines[j]
+
+                # Stop if we hit another test failure
+                if re.match(test_pattern, error_line):
+                    break
+
+                # Check if this is an error line
+                if error_line.startswith("E ") or (error_line.startswith("E") and len(error_line) > 1 and error_line[1].isspace()):
+                    # Extract error type and message
+                    error_content = error_line.lstrip("E").strip()
+                    # Format: "module.ErrorType: message" - find the error type part
+                    # Error types are typically after a dot and before the first colon
+                    if ":" in error_content:
+                        # Split on first colon to get error class and message
+                        parts = error_content.split(":", 1)
+                        error_type_full = parts[0].strip()
+                        error_message = parts[1].strip() if len(parts) > 1 else ""
+
+                        # Extract just the error type name (last part after dot)
+                        if "." in error_type_full:
+                            error_type = error_type_full.split(".")[-1]
+                        else:
+                            error_type = error_type_full
+
+                        break
+
+                j += 1
+
+            if error_type:
+                errors.append((test_name, error_type, error_message))
+
+        i += 1
+
+    return errors
+
+
 def format_color(text, color_code):
     """Apply ANSI color code to text."""
     return f"\033[{color_code}m{text}\033[0m"
@@ -148,43 +239,66 @@ def main():
         print("No warnings or errors found (empty log file)")
         return 0
 
-    # Parse warnings
+    # Parse warnings and errors
     warnings = parse_warnings(log_content)
+    errors = parse_errors(log_content)
 
-    if not warnings:
-        print("No warnings found in test log")
+    if not warnings and not errors:
+        print("No warnings or errors found in test log")
         return 0
-
-    # Sort by count (descending)
-    warnings_sorted = sorted(warnings, key=lambda x: x[3], reverse=True)
 
     # Format output
     use_color = not args.no_color
 
     if use_color:
         header = format_color(f"=== Test Log Analysis: {args.log_file} ===", "1")
-        section_header = format_color("WARNINGS", "1;34")  # Bold blue
+        warnings_header = format_color("WARNINGS", "1;34")  # Bold blue
+        errors_header = format_color("ERRORS", "1;31")  # Bold red
         count_fmt = lambda c: format_color(f"[{c} occurrence{'s' if c > 1 else ''}]", "1")  # Bold
         location_fmt = lambda l: format_color(l, "36")  # Cyan
+        test_fmt = lambda t: format_color(t, "1;33")  # Bold yellow
     else:
         header = f"=== Test Log Analysis: {args.log_file} ==="
-        section_header = "WARNINGS"
+        warnings_header = "WARNINGS"
+        errors_header = "ERRORS"
         count_fmt = lambda c: f"[{c} occurrence{'s' if c > 1 else ''}]"
         location_fmt = lambda l: l
+        test_fmt = lambda t: t
 
     print(header)
     print()
-    print(f"{section_header} ({len(warnings_sorted)} unique):")
-    print("─" * 50)
 
-    for warning_type, message, location, count in warnings_sorted:
-        print(f"{count_fmt(count)} {warning_type}")
-        print(f"  Location: {location_fmt(location)}")
-        print(f"  Message: {message}")
-        print()
+    # Display errors first
+    if errors:
+        print(f"{errors_header} ({len(errors)}):")
+        print("─" * 50)
+        for test_name, error_type, error_message in errors:
+            print(f"{test_fmt(test_name)}")
+            print(f"  Error: {error_type}")
+            if error_message:
+                print(f"  Message: {error_message}")
+            print()
+
+    # Display warnings
+    if warnings:
+        warnings_sorted = sorted(warnings, key=lambda x: x[3], reverse=True)
+        print(f"{warnings_header} ({len(warnings_sorted)} unique):")
+        print("─" * 50)
+
+        for warning_type, message, location, count in warnings_sorted:
+            print(f"{count_fmt(count)} {warning_type}")
+            print(f"  Location: {location_fmt(location)}")
+            print(f"  Message: {message}")
+            print()
 
     # Print summary
-    summary = f"Summary: {len(warnings_sorted)} unique warnings"
+    summary_parts = []
+    if errors:
+        summary_parts.append(f"{len(errors)} error{'s' if len(errors) > 1 else ''}")
+    if warnings:
+        summary_parts.append(f"{len(warnings)} unique warning{'s' if len(warnings) > 1 else ''}")
+
+    summary = f"Summary: {', '.join(summary_parts)}"
     if use_color:
         summary = format_color(summary, "1")  # Bold
     print(summary)


### PR DESCRIPTION
This pull request introduces improvements to the test workflow and log analysis, updates to asset metadata handling, and enhancements to test infrastructure. The main changes focus on capturing and analyzing test logs, updating methods for fetching asset event records to align with newer APIs, and providing a mock IO manager for more flexible testing.

**Test workflow and log analysis improvements:**

* All test-related makefile targets (`test`, `test_slow`, `test_integration`, `test_deploy`, `test_all`) now capture output into `tests/test.log` using `tee`, and a new `test_report` target has been added to analyze the log for warnings and errors via `scripts/parse_test_log.py`. The documentation has been updated with instructions and example output for using this feature. [[1]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0L71-R121) [[2]](diffhunk://#diff-13a4aa523e31731d3925084fec85f8f815706e0cb20379999ce361f15aa0d32cR171-R204)
* The Makefile now explicitly sets the shell to bash and enables strict error handling for more robust script execution.

<img width="2210" height="537" alt="image" src="https://github.com/user-attachments/assets/80119b14-c84c-4381-a670-041e66c1af23" />


**Asset metadata and event record handling:**

* The asset metadata export logic has been updated to use `fetch_materializations` and `AssetRecordsFilter` instead of the deprecated `get_event_records` and `EventRecordsFilter`, ensuring compatibility with newer Dagster APIs. [[1]](diffhunk://#diff-40b377f2a575ce148d127330ddb9f09388ad0b31a8a02b1fcc0e6fe3dfac45d5L14-R14) [[2]](diffhunk://#diff-40b377f2a575ce148d127330ddb9f09388ad0b31a8a02b1fcc0e6fe3dfac45d5L220-R224)
* The code now correctly accesses the event timestamp from `event_log_entry.timestamp` instead of the top-level event record, fixing potential issues in date extraction.
* In AHN metadata computation, the check for the `force` flag has been fixed to use the correct context attribute.

**Test infrastructure enhancements:**

* A new `MockAssetIOManager` and corresponding `mock_asset_io_manager` factory are introduced for tests, allowing pre-configured mock values to be injected for asset loading, which supports more flexible and isolated unit testing.
* Test code now imports `AssetSpec` and `io_manager` to support the new mock IO manager functionality.

**Other improvements:**

* The reconstruction asset runner now correctly retrieves configuration values from the updated context attribute.

Fixes #223 , fixes #224, fixes #225