### PR TITLE
Improve docker based development

### DIFF
--- a/.claude/plans/00-overview.md
+++ b/.claude/plans/00-overview.md
@@ -1,0 +1,35 @@
+# Test Improvement Plan — Overview
+
+## Problem Statement
+
+The 3dbag-pipeline test suite suffers from three interconnected problems:
+
+1. **Slow tests** — Many "fast" tests make live HTTP requests to external APIs (PDOK, basisdata.nl, GitHub gists), adding seconds of latency and risking CI flakes from network issues.
+
+2. **Brittle asset chain tests** — Tests in `floors_estimation` and `core/input` depend on database tables created by *previous* tests. If test order changes, a test fails midway, or you want to run a single test in isolation, the chain breaks.
+
+3. **Duplicated infrastructure** — All 4 packages copy-paste ~60 lines of identical conftest boilerplate (env var reading, marker registration, skip logic, database fixture).
+
+4. **Monolithic test data** — A single `test_data_v14.zip` blob serves all packages. Updating test data for one package requires rebuilding the entire zip.
+
+5. **No middle-ground tests** — The only way to test multi-asset workflows is full integration tests requiring external tool binaries (`@pytest.mark.needs_tools`). There's no lightweight way to test asset graph wiring.
+
+## Staged Plan
+
+| Stage | File | Effort | Impact | Summary |
+|-------|------|--------|--------|---------|
+| 1 | `01-mark-network-tests.md` | Low | High | Mark live-network tests, add `@pytest.mark.network` |
+| 2 | `02-extract-conftest-boilerplate.md` | Low | Medium | DRY up shared conftest code into a pytest plugin |
+| 3 | `03-mock-network-tests.md` | Medium | High | Add mocked variants of HTTP-calling tests |
+| 4 | `04-break-sequential-chains.md` | Medium | High | Decouple sequential DB-dependent test chains |
+| 5 | `05-database-isolation.md` | Medium | High | Add transaction rollback fixtures for test isolation |
+| 6 | `06-graph-wiring-tests.md` | High | High | Add lightweight `materialize()` tests for asset graphs |
+
+## What's Already Good
+
+- `test_automation_conditions.py` and `test_ahn_automation.py` — exemplary Dagster tests using `evaluate_automation_conditions()`, `DagsterInstance.ephemeral()`, `ResourceDefinition.mock_resource()`, and `unittest.mock.patch`. These require no database, no network, no tools.
+- `test_code_location.py` in all 3 packages — `Definitions.validate_loadable()` catches import/wiring errors cheaply.
+- `MockAssetIOManager` in `core/tests/conftest.py` — good pattern for stubbing upstream assets in integration tests.
+- `mock_preprocessed_features` / `mock_inferenced_floors` in `floors_estimation/tests/conftest.py` — in-memory DataFrame fixtures that avoid DB dependency.
+
+These patterns should be extended to more tests across the codebase.

--- a/.claude/plans/01-mark-network-tests.md
+++ b/.claude/plans/01-mark-network-tests.md
@@ -1,0 +1,115 @@
+# Stage 1: Mark Live-Network Tests
+
+**Effort:** Low (< 1 hour)
+**Impact:** High — prevents CI flakes from network issues, makes `make test` reliable offline
+
+## Problem
+
+Several tests make live HTTP requests but are NOT marked as `@pytest.mark.slow`, so they run in every `make test` invocation. A flaky network or API downtime causes false failures.
+
+## Affected Tests
+
+### `packages/common/tests/test_requests.py`
+- **Line 13** `test_get_metadata()` — calls `https://api.pdok.nl/brt/top10nl/download/v1_0/dataset`
+- **Line 42** `test_download_as_str()` — calls `https://gist.githubusercontent.com/...AHN4.md5`
+- **Line 48** `test_download_file()` — same GitHub gist URL
+- **Line 53** `test_download_file_2()` — same GitHub gist URL
+
+Already correctly marked as slow:
+- Line 18 `test_download_link()` — `@pytest.mark.slow`
+- Line 59 `test_download_extra()` — `@pytest.mark.slow`
+
+### `packages/core/tests/test_assets_ahn.py`
+- **Line 27** `test_download_ahn_index()` — calls `https://service.pdok.nl` (AHN index WFS)
+- **Line 33** `test_download_ahn_index_geometry()` — same
+- **Line 39** `test_get_checksums()` — calls `https://basisdata.nl/hwh-ahn/` checksum files
+- **Line 54** `test_checksums_for_ahn()` — calls same checksum URLs (3 times, for AHN 3/4/5)
+- **Line 69** `test_tile_index_ahn()` — calls AHN index + checksum URLs
+
+Already correctly marked:
+- Line 75 `test_laz_files_ahn3()` — `@pytest.mark.slow`
+- Line 92 `test_laz_files_ahn4()` — `@pytest.mark.slow`
+- Line 108 `test_laz_files_ahn5()` — `@pytest.mark.slow`
+
+## Implementation
+
+### Step 1: Add `network` marker to all conftest.py files
+
+In each package's `conftest.py`, add to `pytest_configure`:
+```python
+config.addinivalue_line("markers", "network: mark test as requiring network access")
+```
+
+And in `pytest_collection_modifyitems`, add:
+```python
+if not config.getoption("--run-slow"):
+    skip_network = pytest.mark.skip(reason="need --run-slow option to run")
+    for item in items:
+        if "network" in item.keywords:
+            item.add_marker(skip_network)
+```
+
+Note: reusing `--run-slow` to gate network tests avoids adding yet another CLI flag. Alternatively, add `--run-network` if you want finer control.
+
+### Step 2: Mark the tests
+
+In `packages/common/tests/test_requests.py`:
+```python
+@pytest.mark.network
+def test_get_metadata(): ...
+
+@pytest.mark.network
+def test_download_as_str(): ...
+
+@pytest.mark.network
+def test_download_file(tmp_path): ...
+
+@pytest.mark.network
+def test_download_file_2(tmp_path): ...
+```
+
+In `packages/core/tests/test_assets_ahn.py`:
+```python
+@pytest.mark.network
+def test_download_ahn_index(): ...
+
+@pytest.mark.network
+def test_download_ahn_index_geometry(): ...
+
+@pytest.mark.network
+@pytest.mark.parametrize(...)
+def test_get_checksums(ahn_version): ...
+
+@pytest.mark.network
+def test_checksums_for_ahn(): ...
+
+@pytest.mark.network
+def test_tile_index_ahn(): ...
+```
+
+### Step 3: Update Makefile
+
+In the `test_slow` target, ensure `--run-slow` is passed (it already is), which now also enables `network` tests.
+
+Optionally add a dedicated target:
+```makefile
+test_network:
+    docker compose -p $(COMPOSE_PROJECT_NAME) exec bag3d-core pytest ... --run-slow -m network
+```
+
+## Files Modified
+
+- `packages/common/tests/conftest.py` — add marker + skip logic
+- `packages/core/tests/conftest.py` — add marker + skip logic
+- `packages/common/tests/test_requests.py` — add `@pytest.mark.network` to 4 tests
+- `packages/core/tests/test_assets_ahn.py` — add `@pytest.mark.network` to 5 tests
+
+## Verification
+
+```bash
+# Should pass without network access (e.g., in airplane mode)
+make test
+
+# Should run all tests including network
+make test_slow
+```

--- a/.claude/plans/02-extract-conftest-boilerplate.md
+++ b/.claude/plans/02-extract-conftest-boilerplate.md
@@ -1,0 +1,135 @@
+# Stage 2: Extract Conftest Boilerplate into Shared Plugin
+
+**Effort:** Low-Medium (1-2 hours)
+**Impact:** Medium — reduces maintenance burden, ensures consistent test infrastructure
+
+## Problem
+
+All 4 package conftest.py files duplicate ~60 lines of identical code:
+- Env var reading (`BAG3D_PG_HOST`, `BAG3D_PG_PORT`, etc.) — 6 lines
+- `pytest_addoption` — `--run-slow`, `--run-all` — 10 lines
+- `pytest_configure` — marker registration — 6 lines
+- `pytest_collection_modifyitems` — skip logic — 15 lines
+- `database` fixture — 5 lines
+- `test_data_dir` fixture — 3 lines
+
+When a new marker or option is added, it must be copy-pasted to all 4 files (and currently `--run-deploy` only exists in core).
+
+## Implementation
+
+### Step 1: Create shared pytest plugin module
+
+Create `packages/common/src/bag3d/common/testing/conftest_plugin.py`:
+
+```python
+"""Shared pytest plugin for all bag3d test packages.
+
+Register via conftest.py:
+    pytest_plugins = ["bag3d.common.testing.conftest_plugin"]
+"""
+import os
+from pathlib import Path
+
+import pytest
+from bag3d.common.resources.database import DatabaseResource
+
+
+LOCAL_DIR = os.getenv("BAG3D_TEST_DATA")
+HOST = os.getenv("BAG3D_PG_HOST")
+PORT = int(os.getenv("BAG3D_PG_PORT", "5432"))
+USER = os.getenv("BAG3D_PG_USER")
+PASSWORD = os.getenv("BAG3D_PG_PASSWORD")
+DB_NAME = os.getenv("BAG3D_PG_DATABASE")
+
+
+def pytest_addoption(parser):
+    parser.addoption("--run-slow", action="store_true", default=False, help="run slow tests")
+    parser.addoption("--run-all", action="store_true", default=False, help="run all tests, including the ones that needs local builds of tools")
+    parser.addoption("--run-deploy", action="store_true", default=False, help="run deployment tests")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "needs_tools: mark test as needing local builds of tools")
+    config.addinivalue_line("markers", "needs_deploy: mark test as needing the dockerized deployment setup")
+    config.addinivalue_line("markers", "network: mark test as requiring network access")
+
+
+def pytest_collection_modifyitems(config, items):
+    marker_option_pairs = [
+        ("slow", "--run-slow", "need --run-slow option to run"),
+        ("network", "--run-slow", "need --run-slow option to run"),
+        ("needs_tools", "--run-all", "needs the --run-all option to run"),
+        ("needs_deploy", "--run-deploy", "needs the --run-deploy option to run"),
+    ]
+    for marker_name, option, reason in marker_option_pairs:
+        if not config.getoption(option):
+            skip_marker = pytest.mark.skip(reason=reason)
+            for item in items:
+                if marker_name in item.keywords:
+                    item.add_marker(skip_marker)
+
+
+@pytest.fixture
+def database():
+    db = DatabaseResource(host=HOST, port=PORT, user=USER, password=PASSWORD, dbname=DB_NAME)
+    yield db
+
+
+@pytest.fixture(scope="session")
+def test_data_dir():
+    yield Path(LOCAL_DIR)
+```
+
+### Step 2: Create `__init__.py`
+
+Create `packages/common/src/bag3d/common/testing/__init__.py` (empty file).
+
+### Step 3: Simplify each package's conftest.py
+
+Each conftest.py becomes much shorter. For example, `packages/core/tests/conftest.py`:
+
+```python
+# Register the shared plugin
+pytest_plugins = ["bag3d.common.testing.conftest_plugin"]
+
+# Package-specific fixtures only
+from bag3d.common.resources.files import FileStoreResource
+# ... rest of core-specific fixtures (gdal, validation, mock assets, etc.)
+
+@pytest.fixture
+def file_store(tmp_path):
+    yield FileStoreResource(data_dir=str(tmp_path))
+
+# ... other core-specific fixtures
+```
+
+Remove from each conftest.py:
+- `pytest_addoption`, `pytest_configure`, `pytest_collection_modifyitems` (provided by plugin)
+- `database` fixture (provided by plugin)
+- `test_data_dir` fixture (provided by plugin)
+- Env var declarations at module level (provided by plugin)
+
+### Step 4: Handle the `--run-deploy` option
+
+Currently only `core/tests/conftest.py` has `--run-deploy`. By moving it to the shared plugin, all packages get it, which is harmless (the marker is simply never used in other packages).
+
+## Files Modified
+
+- **New:** `packages/common/src/bag3d/common/testing/__init__.py`
+- **New:** `packages/common/src/bag3d/common/testing/conftest_plugin.py`
+- `packages/common/tests/conftest.py` — remove boilerplate, add `pytest_plugins` line
+- `packages/core/tests/conftest.py` — remove boilerplate, add `pytest_plugins` line
+- `packages/floors_estimation/tests/conftest.py` — remove boilerplate, add `pytest_plugins` line
+- `packages/party_walls/tests/conftest.py` — remove boilerplate, add `pytest_plugins` line
+
+## Verification
+
+```bash
+# Run each package's tests independently — all should still pass
+make test
+
+# Verify markers work
+docker compose -p bag3d-dev exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/ --co -m slow
+docker compose -p bag3d-dev exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/ --co -m network
+```

--- a/.claude/plans/03-mock-network-tests.md
+++ b/.claude/plans/03-mock-network-tests.md
@@ -1,0 +1,156 @@
+# Stage 3: Add Mocked Variants of Network Tests
+
+**Effort:** Medium (2-3 hours)
+**Impact:** High — ensures core parsing/processing logic is tested without network dependency
+
+## Problem
+
+After Stage 1 marks network tests, the "fast" test suite loses coverage for important parsing and processing logic that's currently only tested via live HTTP calls. We need mocked versions that test the same logic using fixture data.
+
+## Tests to Add Mocked Variants For
+
+### 3.1 `test_requests.py` — Mock HTTP responses
+
+**Current tests and what they actually validate:**
+- `test_get_metadata()` — validates JSON response parsing from PDOK API
+- `test_download_as_str()` — validates string download and content parsing
+- `test_download_file()` / `test_download_file_2()` — validates file download and path handling
+
+**Implementation using `responses` library:**
+
+Add `responses` to dev dependencies:
+```bash
+uv add -p packages/common --dev responses
+```
+
+Create `packages/common/tests/test_requests_mocked.py`:
+
+```python
+"""Mocked variants of network tests — run without network access."""
+import responses
+
+from bag3d.common.utils.requests import (
+    get_metadata,
+    download_as_str,
+    download_file,
+)
+
+MOCK_PDOK_RESPONSE = {
+    "_links": {"self": {"href": "..."}},
+    "tilesPerFormat": [{"format": "gml", "tiles": []}],
+}
+
+MOCK_MD5_CONTENT = "56c731a1814dd73c79a0a5347f8a04c7  C_01CZ1.LAZ\naaa111  C_50CN2.LAZ\n"
+
+
+@responses.activate
+def test_get_metadata_mocked():
+    responses.add(
+        responses.GET,
+        "https://api.pdok.nl/brt/top10nl/download/v1_0/dataset",
+        json=MOCK_PDOK_RESPONSE,
+        status=200,
+    )
+    res = get_metadata("https://api.pdok.nl/brt/top10nl/download/v1_0/dataset")
+    assert res is not None
+
+
+@responses.activate
+def test_download_as_str_mocked():
+    url = "https://example.com/AHN4.md5"
+    responses.add(responses.GET, url, body=MOCK_MD5_CONTENT, status=200)
+    res = download_as_str(url=url)
+    assert res.split("\n", 1)[0] == "56c731a1814dd73c79a0a5347f8a04c7  C_01CZ1.LAZ"
+
+
+@responses.activate
+def test_download_file_mocked(tmp_path):
+    url = "https://example.com/AHN4.md5"
+    responses.add(responses.GET, url, body=MOCK_MD5_CONTENT, status=200)
+    res = download_file(url=url, target_path=tmp_path / "test.md5")
+    assert res == tmp_path / "test.md5"
+    assert res.read_text().startswith("56c731a1814dd73c79a0a5347f8a04c7")
+```
+
+### 3.2 `test_assets_ahn.py` — Mock AHN index and checksum downloads
+
+**Current tests and what they actually validate:**
+- `test_download_ahn_index()` — validates WFS response parsing (1407 tiles)
+- `test_get_checksums()` — validates MD5/SHA256 file parsing
+- `test_tile_index_ahn()` — validates combined index+URL building
+
+**Implementation using fixtures + `unittest.mock.patch`:**
+
+The `test_ahn_automation.py` file already demonstrates this pattern beautifully (lines 248-249):
+```python
+with (
+    patch("bag3d.core.sensors.get_checksums", return_value=CHECKSUMS_V1),
+    patch("bag3d.core.sensors.download_ahn_index", return_value=TILE_INDEX),
+):
+```
+
+Create `packages/core/tests/test_assets_ahn_mocked.py`:
+
+```python
+"""Mocked variants of AHN download tests — run without network access."""
+from unittest.mock import patch
+from bag3d.core.assets.ahn.download import get_checksums, tile_index_ahn
+
+# Fixture data: a small subset of the real AHN index
+MOCK_AHN_INDEX = {
+    "01cz1": None,
+    "32bz1": None,
+    "50cn2": None,
+}
+
+MOCK_AHN_INDEX_WITH_GEOM = {
+    "01cz1": {"type": "Polygon", "coordinates": [[[140000, 600000], [140000, 606250], [145000, 606250], [145000, 600000], [140000, 600000]]]},
+    "32bz1": {"type": "Polygon", "coordinates": [[[160000, 380000], [160000, 386250], [165000, 386250], [165000, 380000], [160000, 380000]]]},
+}
+
+MOCK_MD5_TEXT = "aaa111  C_01CZ1.LAZ\nbbb222  C_32BZ1.LAZ\n"
+
+
+def test_get_checksums_parsing():
+    """Test that get_checksums correctly parses MD5 text format."""
+    with patch("bag3d.core.assets.ahn.download.download_as_str", return_value=MOCK_MD5_TEXT):
+        checksums = get_checksums("https://example.com/checksums", ahn_version=3)
+    assert checksums == {"C_01CZ1.LAZ": "aaa111", "C_32BZ1.LAZ": "bbb222"}
+
+
+def test_tile_index_ahn_structure():
+    """Test that tile_index_ahn builds correct structure from components."""
+    # Patch both the index download and checksum downloads
+    with (
+        patch("bag3d.core.assets.ahn.download.download_ahn_index", return_value=MOCK_AHN_INDEX_WITH_GEOM),
+        # ... patch URL building
+    ):
+        result = tile_index_ahn()
+    assert isinstance(result, dict)
+    # Verify structure has expected keys
+```
+
+Note: the exact patches depend on the internal implementation of `tile_index_ahn`. Read `packages/core/src/bag3d/core/assets/ahn/download.py` to determine the right patch targets.
+
+### 3.3 `test_geodata.py` — already mostly local
+
+`test_info_exes`, `test_info_data`, `test_ogr2postgres` use local test data files and GDAL executables. These don't need mocking. Only `test_parse_ogrinfo` and `test_geojson_poly_to_wkt` are pure-logic tests that don't need any external resources.
+
+No changes needed for this file.
+
+## Files Modified
+
+- **New:** `packages/common/tests/test_requests_mocked.py`
+- **New:** `packages/core/tests/test_assets_ahn_mocked.py`
+- `packages/common/pyproject.toml` — add `responses` to dev dependencies
+
+## Verification
+
+```bash
+# Run only the new mocked tests (should work without network/Docker DB)
+pytest packages/common/tests/test_requests_mocked.py -v
+pytest packages/core/tests/test_assets_ahn_mocked.py -v
+
+# Full test suite still passes
+make test
+```

--- a/.claude/plans/04-break-sequential-chains.md
+++ b/.claude/plans/04-break-sequential-chains.md
@@ -1,0 +1,181 @@
+# Stage 4: Break Sequential Test Chains
+
+**Effort:** Medium (2-4 hours)
+**Impact:** High — enables running individual tests in isolation, faster iterative development
+
+## Problem
+
+Several test files contain tests that MUST run in a specific order because each test creates database tables that subsequent tests depend on. This means:
+- You cannot run a single test with `pytest -k test_name`
+- A failure in an early test cascades to all later tests
+- Adding a new test requires understanding the entire chain
+
+### The `floors_estimation` chain (worst offender)
+
+In `packages/floors_estimation/tests/test_floors_estimation.py`, the implicit execution order is:
+
+```
+test_bag3d_features        → creates floors_estimation.building_features_bag3d
+test_external_features     → creates floors_estimation.building_features_external
+test_all_features          → reads both tables above, creates floors_estimation.building_features_all
+test_preprocessed_features → reads building_features_all, returns DataFrame
+test_inferenced_floors     → uses mock_preprocessed_features (independent!)
+test_predictions_table     → uses mock_inferenced_floors (independent!)
+test_save_cjfiles          → uses mock_inferenced_floors (independent!)
+```
+
+The first 4 tests form a chain. The last 3 are already decoupled via mock fixtures.
+
+### The `core/input` chain
+
+In `packages/core/tests/test_assets_input.py`:
+
+```
+test_bag_kas_warenhuis → needs lvbag.pandactueelbestaand AND top10nl.gebouw (from test data)
+test_bag_bag_overlap   → needs lvbag.pandactueelbestaand (from test data)
+```
+
+These aren't chained to each other, but they depend on pre-loaded database tables from the test data zip.
+
+## Implementation
+
+### 4.1 Fix `floors_estimation` chain with module-scoped fixtures
+
+Replace the implicit chain with explicit fixtures that materialize prerequisites once per module:
+
+In `packages/floors_estimation/tests/conftest.py`, add:
+
+```python
+@pytest.fixture(scope="module")
+def materialized_bag3d_features(database, mock_features_file_index):
+    """Materialize bag3d_features once for the test module."""
+    from bag3d.floors_estimation.assets.floors_estimation import bag3d_features, FloorsEstimationConfig
+    result = bag3d_features(FloorsEstimationConfig(), mock_features_file_index, database)
+    return result.value
+
+
+@pytest.fixture(scope="module")
+def materialized_external_features(database):
+    """Materialize external_features once for the test module."""
+    from bag3d.floors_estimation.assets.floors_estimation import external_features
+    result = external_features(database)
+    return result.value
+
+
+@pytest.fixture(scope="module")
+def materialized_all_features(database, materialized_bag3d_features, materialized_external_features):
+    """Materialize all_features once for the test module."""
+    from bag3d.floors_estimation.assets.floors_estimation import all_features
+    result = all_features(materialized_external_features, materialized_bag3d_features, database)
+    return result.value
+```
+
+Then rewrite the tests to use these fixtures explicitly:
+
+```python
+def test_bag3d_features(materialized_bag3d_features, database):
+    """Test that bag3d_features creates the expected table."""
+    building_feature_table = PostgresTableIdentifier("floors_estimation", "building_features_bag3d")
+    assert table_exists(database, building_feature_table) is True
+
+
+def test_external_features(materialized_external_features, database):
+    """Test that external_features creates the expected table."""
+    external_features_table = PostgresTableIdentifier("floors_estimation", "building_features_external")
+    assert table_exists(database, external_features_table) is True
+
+
+def test_all_features(materialized_all_features, database):
+    """Test that all_features creates the expected table."""
+    all_features_table = PostgresTableIdentifier("floors_estimation", "building_features_all")
+    assert table_exists(database, all_features_table) is True
+
+
+def test_preprocessed_features(materialized_all_features, database):
+    """Test that preprocessed_features works with materialized all_features."""
+    all_features_table = PostgresTableIdentifier("floors_estimation", "building_features_all")
+    data = preprocessed_features(all_features_table, database)
+    assert data is not None
+    assert data.shape[0] == 6
+```
+
+**Key benefit:** Now `pytest -k test_preprocessed_features` works — pytest will automatically materialize all prerequisite fixtures.
+
+### 4.2 Make `core/input` tests self-contained
+
+The input tests depend on `lvbag.pandactueelbestaand` and `top10nl.gebouw` existing in the database. These are loaded by the test data setup. To make tests self-contained:
+
+**Option A (recommended): Add a fixture that verifies prerequisites exist**
+
+```python
+@pytest.fixture
+def require_source_tables(database):
+    """Skip test if source data tables don't exist."""
+    required = [
+        PostgresTableIdentifier("lvbag", "pandactueelbestaand"),
+        PostgresTableIdentifier("top10nl", "gebouw"),
+    ]
+    for tbl in required:
+        if not table_exists(database, tbl):
+            pytest.skip(f"Required table {tbl} not found — run make download and load test data first")
+```
+
+Then use in tests:
+```python
+def test_bag_kas_warenhuis(database, require_source_tables):
+    ...
+```
+
+**Option B: Create minimal fixtures with synthetic data**
+
+For pure unit testing, create fixtures that insert 5-10 rows into temporary tables:
+
+```python
+@pytest.fixture
+def synthetic_pandactueelbestaand(database):
+    """Create a minimal pandactueelbestaand table for testing."""
+    tbl = PostgresTableIdentifier("test_lvbag", "pandactueelbestaand")
+    # Create table with minimal schema
+    database.connect.send_query(SQL("""
+        CREATE SCHEMA IF NOT EXISTS test_lvbag;
+        CREATE TABLE test_lvbag.pandactueelbestaand AS
+        SELECT * FROM lvbag.pandactueelbestaand LIMIT 10;
+    """))
+    yield tbl
+    drop_table(database, tbl, get_dagster_logger())
+    database.connect.send_query(SQL("DROP SCHEMA IF EXISTS test_lvbag CASCADE;"))
+```
+
+This option requires modifying the asset functions to accept table identifiers as parameters (which they already do — `bag_kas_warenhuis` takes `bag_pandactueelbestaand` and `top10nl_gebouw` as inputs).
+
+### 4.3 Document test execution requirements
+
+Add a note to the relevant test files explaining that they require test data:
+
+```python
+"""Tests for input assets.
+
+Prerequisites:
+    - Database must have lvbag.pandactueelbestaand table loaded (via make download + test data setup)
+    - Database must have top10nl.gebouw table loaded
+"""
+```
+
+## Files Modified
+
+- `packages/floors_estimation/tests/conftest.py` — add module-scoped materialization fixtures
+- `packages/floors_estimation/tests/test_floors_estimation.py` — rewrite to use explicit fixtures
+- `packages/core/tests/test_assets_input.py` — add `require_source_tables` fixture or skip logic
+
+## Verification
+
+```bash
+# Each test should be runnable independently
+docker compose -p bag3d-dev exec bag3d-floors-estimation pytest /opt/3dbag-pipeline/packages/floors_estimation/tests/test_floors_estimation.py::test_preprocessed_features -v
+
+# The full module still passes
+docker compose -p bag3d-dev exec bag3d-floors-estimation pytest /opt/3dbag-pipeline/packages/floors_estimation/tests/test_floors_estimation.py -v
+
+# Full suite still passes
+make test
+```

--- a/.claude/plans/05-database-isolation.md
+++ b/.claude/plans/05-database-isolation.md
@@ -1,0 +1,134 @@
+# Stage 5: Database Test Isolation
+
+**Effort:** Medium (2-3 hours)
+**Impact:** High — prevents test pollution, enables parallel test execution
+
+## Problem
+
+Multiple tests write to the same database without cleanup guarantees. If a test fails midway after creating a table but before dropping it, the stale table may cause subsequent tests or re-runs to behave differently. Examples:
+
+- `packages/common/tests/test_database.py:24` — `test_drop_table` creates `public.non_existing_table`
+- `packages/common/tests/test_database.py:75` — `test_postgrestable_from_query` creates `public.test_table` and has explicit "clean up if table exists from previous run" code (line 82-83), proving the problem exists
+- `packages/core/tests/test_assets_bag.py:21` — `test_load_bag_layer` creates then drops `lvbag.test_ligplaats`
+- `packages/core/tests/test_assets_bag.py:56` — `test_stage_bag_layer` creates then drops `stage_lvbag.ligplaats`
+- `packages/floors_estimation/tests/test_floors_estimation.py` — creates tables in `floors_estimation` schema that persist
+
+## Implementation
+
+### 5.1 Create a transaction-based database fixture
+
+Add to the shared testing plugin (`packages/common/src/bag3d/common/testing/conftest_plugin.py`):
+
+```python
+@pytest.fixture
+def database_transaction(database):
+    """Database resource that rolls back all changes after the test.
+
+    Use this instead of `database` for tests that write to the database
+    but shouldn't leave permanent state.
+    """
+    # Get the underlying psycopg connection
+    conn = database.connect._conn  # adjust based on actual DatabaseResource internals
+    conn.autocommit = False
+
+    yield database
+
+    conn.rollback()
+    conn.autocommit = True
+```
+
+**Important caveat:** This requires understanding how `DatabaseResource.connect` manages its connection. The fixture needs to wrap the same connection that the asset/function under test uses. If `DatabaseResource` creates new connections per query, this approach won't work and we need an alternative.
+
+### 5.2 Alternative: Schema-per-test isolation
+
+If transaction rollback isn't feasible due to how the DB resource manages connections, use unique schemas per test:
+
+```python
+@pytest.fixture
+def isolated_schema(database):
+    """Create a unique schema for this test and drop it after."""
+    import uuid
+    schema_name = f"test_{uuid.uuid4().hex[:8]}"
+    database.connect.send_query(SQL("CREATE SCHEMA {}").format(Identifier(schema_name)))
+    yield schema_name
+    database.connect.send_query(SQL("DROP SCHEMA {} CASCADE").format(Identifier(schema_name)))
+```
+
+Tests that create tables use the isolated schema:
+```python
+def test_load_bag_layer(database, isolated_schema, ...):
+    test_table = PostgresTableIdentifier(isolated_schema, "test_ligplaats")
+    res = load_bag_layer(db_connection=database, ..., new_table=test_table, ...)
+    assert res is True
+    # No manual cleanup needed — schema dropped by fixture
+```
+
+### 5.3 Add cleanup guards to existing tests
+
+For tests that can't easily be refactored, add `try/finally` cleanup patterns. Some tests already do this (`test_assets_deploy.py:44`), but others don't:
+
+```python
+def test_bag_kas_warenhuis(database):
+    logger = get_dagster_logger()
+    new_table = PostgresTableIdentifier("reconstruction_input", "bag_kas_warenhuis")
+    try:
+        res = intermediary.bag_kas_warenhuis(...)
+        assert isinstance(res.value, PostgresTableIdentifier)
+    finally:
+        drop_table(database, new_table, logger)
+```
+
+### 5.4 Add database state validation fixture
+
+A fixture that runs before each test to verify expected database state:
+
+```python
+@pytest.fixture(autouse=True)
+def _verify_db_clean_state(database, request):
+    """Log a warning if leftover test tables exist."""
+    # Only check for test modules that write to DB
+    if "test_assets" not in request.node.nodeid:
+        return
+    # Check for common leftover tables
+    known_test_tables = [
+        PostgresTableIdentifier("public", "non_existing_table"),
+        PostgresTableIdentifier("public", "test_table"),
+    ]
+    for tbl in known_test_tables:
+        if table_exists(database, tbl):
+            import warnings
+            warnings.warn(f"Leftover table {tbl} found before test — cleaning up")
+            drop_table(database, tbl, get_dagster_logger())
+```
+
+## Investigation Needed
+
+Before implementing, we need to check how `DatabaseResource.connect` manages connections:
+
+```bash
+# Check the implementation
+grep -n "class DatabaseConnection" packages/common/src/bag3d/common/resources/database.py
+grep -n "def send_query" packages/common/src/bag3d/common/resources/database.py
+```
+
+If the connection uses autocommit (common with psycopg3), we need approach 5.2 (schema isolation) instead of 5.1 (transaction rollback).
+
+## Files Modified
+
+- `packages/common/src/bag3d/common/testing/conftest_plugin.py` — add `database_transaction` or `isolated_schema` fixture
+- `packages/common/tests/test_database.py` — use isolation fixture
+- `packages/core/tests/test_assets_bag.py` — use isolation fixture
+- `packages/core/tests/test_assets_input.py` — add cleanup guards
+- `packages/floors_estimation/tests/test_floors_estimation.py` — use isolation fixture where appropriate
+
+## Verification
+
+```bash
+# Run tests twice in a row — second run should produce identical results
+make test && make test
+
+# Run a single test that creates tables — verify no leftover state
+docker compose -p bag3d-dev exec bag3d-core pytest .../test_database.py::test_drop_table -v
+docker compose -p bag3d-dev exec data-postgresql psql -U bag3d_user -d bag3d -c "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename = 'non_existing_table';"
+# Should return 0 rows
+```

--- a/.claude/plans/06-graph-wiring-tests.md
+++ b/.claude/plans/06-graph-wiring-tests.md
@@ -1,0 +1,205 @@
+# Stage 6: Add Graph Wiring Tests with Mock Resources
+
+**Effort:** High (4-6 hours)
+**Impact:** High — provides multi-asset workflow coverage without requiring external tool binaries
+
+## Problem
+
+Currently there are only two ways to test multi-asset workflows:
+1. **Unit tests** — call individual asset functions directly (tests logic but not Dagster wiring)
+2. **Integration tests** (`@pytest.mark.needs_tools`) — run full jobs via `execute_in_process` with real GDAL/roofer/tyler binaries
+
+There's no middle ground that tests:
+- Asset graph wiring (are inputs/outputs connected correctly?)
+- Partition propagation (does a partitioned job pass partition keys correctly?)
+- Resource injection (are all required resources provided?)
+- Job definition correctness (does AssetSelection include all needed assets?)
+
+## Inspiration: Existing Patterns
+
+The codebase already has excellent examples of lightweight Dagster tests:
+
+### `test_automation_conditions.py` — tests asset DAG behavior without any resources
+```python
+MOCK_RESOURCES = {
+    "file_store": dg.ResourceDefinition.mock_resource(),
+    "gdal": dg.ResourceDefinition.mock_resource(),
+    ...
+}
+DEFS = dg.Definitions(assets=AUTOMATED_ASSETS, resources=MOCK_RESOURCES)
+```
+
+### `test_integration.py` — uses `MockAssetIOManager` to stub upstream assets
+```python
+defs = Definitions(
+    resources=resources,
+    assets=[mock_asset_reconstruction_input, mock_asset_tiles, ...],
+    jobs=[job_nl_reconstruct],
+)
+```
+
+## Implementation
+
+### 6.1 Create mock resource implementations
+
+Create `packages/common/src/bag3d/common/testing/mock_resources.py`:
+
+```python
+"""Mock resources for graph wiring tests.
+
+These resources satisfy Dagster's type checking and resource injection
+but return canned responses instead of running real tools.
+"""
+from bag3d.common.resources.executables import CommandRunner
+
+
+class MockCommandResult:
+    """Canned result from a mock command execution."""
+    def __init__(self, success=True, stdout="", stderr=""):
+        self.success = success
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = 0 if success else 1
+
+
+class MockCommandRunner(CommandRunner):
+    """CommandRunner that records calls but doesn't execute anything."""
+    def __init__(self):
+        self.calls = []
+
+    def run(self, cmd_template, **kwargs):
+        self.calls.append((cmd_template, kwargs))
+        return MockCommandResult()
+```
+
+### 6.2 Add graph wiring tests for each job
+
+Create `packages/core/tests/test_job_wiring.py`:
+
+```python
+"""Test that job definitions wire assets correctly.
+
+These tests verify Dagster graph structure without running asset functions.
+They catch issues like:
+- Missing assets in job selection
+- Incorrect asset key prefixes
+- Missing resource definitions
+- Partition definition mismatches
+"""
+import dagster as dg
+from bag3d.core.jobs import (
+    job_nl_reconstruct,
+    job_nl_export,
+    job_ahn3,
+    job_ahn4,
+    job_ahn5,
+)
+from bag3d.core.code_location import defs
+
+
+def test_all_jobs_resolvable():
+    """Every job defined in the code location can be resolved."""
+    for job_name in [
+        "nl_reconstruct",
+        "nl_export",
+        "nl_export_after_floors",
+        "ahn_tile_index",
+        "ahn3",
+        "ahn4",
+        "ahn5",
+        "ahn_metadata_index",
+    ]:
+        job_def = defs.get_job_def(job_name)
+        assert job_def is not None, f"Job {job_name} not found in definitions"
+
+
+def test_partitioned_jobs_have_partition_defs():
+    """Partitioned jobs should have matching partition definitions."""
+    for job_name in ["ahn3", "ahn4", "ahn5", "nl_reconstruct"]:
+        job_def = defs.get_job_def(job_name)
+        # Verify the job can accept a partition key
+        assert job_def.partitions_def is not None or any(
+            asset.partitions_def is not None
+            for asset in job_def.asset_layer.assets_defs_by_key.values()
+        ), f"Job {job_name} expected to be partitioned"
+
+
+def test_job_asset_selections_are_complete():
+    """Each job's asset selection includes all required assets (no dangling inputs)."""
+    # This is implicitly tested by Definitions.validate_loadable(),
+    # but we can add explicit checks for specific jobs
+    for job_name in ["nl_export", "nl_reconstruct"]:
+        job_def = defs.get_job_def(job_name)
+        # Get all assets in the job
+        asset_keys = set(job_def.asset_layer.asset_keys)
+        # Verify expected assets are present
+        assert len(asset_keys) > 0, f"Job {job_name} has no assets"
+```
+
+### 6.3 Add `materialize()` smoke tests for asset subgraphs
+
+For cases where you want to verify that assets can actually execute together (not just wire up), use `dagster.materialize()` with mock resources:
+
+```python
+"""Smoke tests that materialize small asset subgraphs with mock resources.
+
+These tests verify that:
+- Asset functions accept their declared resources
+- Output types match downstream input expectations
+- Partition key propagation works correctly
+"""
+import dagster as dg
+from bag3d.core.assets.ahn.download import md5_ahn3, md5_ahn4, sha256_ahn5
+from unittest.mock import patch
+
+
+def test_checksum_assets_materialize():
+    """Checksum assets can be materialized with mocked HTTP calls."""
+    mock_checksums = {"C_01CZ1.LAZ": "aaa111"}
+
+    with patch("bag3d.core.assets.ahn.download.get_checksums", return_value=mock_checksums):
+        result = dg.materialize(
+            [md5_ahn3],
+            resources={},  # md5_ahn3 takes no resources
+        )
+    assert result.success
+    output = result.output_for_node("md5_ahn3")
+    assert output == mock_checksums
+```
+
+### 6.4 Test resource injection completeness
+
+```python
+def test_all_assets_have_required_resources():
+    """Every asset's required resources are provided in the definitions."""
+    defs_obj = defs  # from code_location
+    # Definitions.validate_loadable() already checks this,
+    # but we can add targeted checks
+    dg.Definitions.validate_loadable(defs_obj)
+```
+
+## Relationship to Existing Tests
+
+| Test Type | What It Tests | Speed | Example |
+|-----------|--------------|-------|---------|
+| `test_code_location.py` | Definitions load without errors | Fast | `test_definitions_loadable` |
+| `test_automation_conditions.py` | Automation logic, no execution | Fast | `test_cron_roots_requested_after_tick` |
+| **New: `test_job_wiring.py`** | **Job structure, asset selection** | **Fast** | **`test_all_jobs_resolvable`** |
+| `test_assets_*.py` | Individual asset logic | Medium | `test_metadata_table_ahn3` |
+| `test_integration.py` | Full pipeline execution | Slow | `test_integration_reconstruction_and_export` |
+
+## Files Modified
+
+- **New:** `packages/common/src/bag3d/common/testing/mock_resources.py`
+- **New:** `packages/core/tests/test_job_wiring.py`
+- Potentially: `packages/party_walls/tests/test_job_wiring.py`, `packages/floors_estimation/tests/test_job_wiring.py`
+
+## Verification
+
+```bash
+# New tests should run fast (no Docker, no tools needed — just Python)
+docker compose -p bag3d-dev exec bag3d-core pytest /opt/3dbag-pipeline/packages/core/tests/test_job_wiring.py -v
+
+# Full suite still passes
+make test
+```

--- a/.claude/plans/refactor-round-2/00-overview.md
+++ b/.claude/plans/refactor-round-2/00-overview.md
@@ -1,0 +1,96 @@
+# Big refactoring round 2
+
+The goals of this refactoring round are:
+
+1. improve developer efficiency when developing the 3dbag-pipeline,
+  - so that iteration is faster,
+  - the cognitive load is lower so that
+    - the code is easier to understand and overview,
+    - picking up development after a long period is easier,
+2. improve the reliability of the the 3dbag-pipeline when producing and deploying a new 3DBAG release so that the production does not halt due to functional bugs that could have been detected and fixed with comprehensive testing,
+3. streamline the production and deployment process by reducing the fragmentation of the production and deployment setup, and by automating as much as possible
+
+After the refactoring, we will have a setup that is,
+- modular,
+- independently and easily testable so that developing and testing assets in isolation is possible,
+- end-to-end tested all the way to releasing the 3DBAG, 
+
+The refactoring impacts two repositories:
+
+- 3dbag-pipeline (contains the pipeline code and docker setup for running the pipeline)
+- 3dbag-admin (contains the setup for deploying the pipeline on our server for testing and production, and the setup for publishing the 3DBAG)
+
+## Improve the docker-based development workflow
+
+Related:
+
+- https://github.com/3DBAG/3dbag-pipeline/issues/206
+- https://github.com/3DBAG/3dbag-pipeline/issues/402
+
+## Refactor tests to reduce dependency on test data
+
+We rely on samples of real inputs and intermediate outputs in our unit and integration tests.
+The reasons behind this are:
+
+- we cannot effectively mock the real spatial data in a way that would allow us to actually execute the tools in tests  that are fundamental to the pipeline (roofer, tyler, cjval etc.),
+- the schema of the input changes (or can change) over time, or there can be errors in the published input data, and we want to detect and react to these changes before going into production.
+
+Therefore, we tried to include everything into our pytest setup (unit and integration tests), with the idea that we can catch almost all errors with the pytest setup.
+But this setup requires that we continuously have to maintain the samples of real inputs and intermediate outputs as the 3dbag-pipeline evolves, and in practice this proved to be very error prone, obscure and time consuming.
+
+However, now that we have multi-tier deployment and testing, controlled by the `DAGSTER_DEPLOYMENT` variable (`pytest`, `user`, `pc`, `production`), we can actually separate the different tiers of testing based on what they ought to do and make the iterative development, testing more efficient.
+
+So then testing tiers become, in order of increasing complexity and duration:
+
+- lint
+  - format check (ruff)
+  - syntax check (ruff)
+  - code style check (ruff)
+  - type check (mypy)
+- pytest: Functional testing of assets, jobs etc. with mocked inputs (mostly or only), run via pytest. Used during  iterative development and in CI. Fast to run. Detects errors in the use of different API-s.
+- user: End-to-end testing with real input, with one specific AHN tile. Run on our server (gilfoyle). Takes about one hour to complete. Detects errors in assumptions about the input and schema drift.
+- pc: End-to-end testing with real input, with a large area that can surface edge cases in the inputs that we would run into in production. Takes multiple hours to run on our server (gilfoyle).
+
+## CI/CD
+
+### Production-candidate
+
+The `pc-*` branch deploys on gilfoyle on push, after all checks succeed.
+Production-candidate test are triggered manually from GitHub with `workflow_dispatch`.
+These runs are very long running, I don't know if that could be an issue with GitHub.
+
+### User tests
+
+Any branch can be deployed on gilfoyle and the `user` test initiated manually with `workflow_dispatch`.
+
+
+## Dockerized publication deployment
+
+Similarly to the dockerized 3dbag-pipline setup, a dockerized publication setup would help us to test the publication and release flow, which is currently untested.
+It also allows us to hook it up to CI, as integration tests.
+
+The services we need:
+
+- Caddy (file server and reverse proxy)
+  - 3DTiles
+  - format downloads
+  - metadata
+  - tile index
+  - Website
+  - docs
+- Geoserver
+  - WFS
+  - WMS
+- 3dbag-api
+- PostgreSQL
+
+## Staging deployment
+
+A login-protected (BasicAuth) staging area where we can test a release fully, with website, docs, webservices and all.
+A login implies some password protection on the webservices too, which I'm not sure how to solve.
+It would be hosted at `https://dev.3dbag.nl`.
+
+## Improve the documentation
+
+Bring the documentation at `https://innovation.3dbag.nl/3dbag-pipeline/` to a level where it can really serve as the re-starting point when we pick up development after a long period.
+

--- a/.claude/plans/refactor-round-3/00-overview.md
+++ b/.claude/plans/refactor-round-3/00-overview.md
@@ -1,0 +1,9 @@
+# Big refactoring round 3
+
+The main goal of this refactoring round is that the 3dbag-pipeline is ready for future improvements.
+
+First and foremost, this means that we can have a uniform feature-based pipeline throughout, and that the party walls calculation is refactor to take CityJSONFeatures as input, instead of CityJSON tiles.
+
+Second, we have fully integrated the floor estimation process, including the building type calculation, so that we can recreate and update all parts of the pipeline from the baseregistrations, instead of having to import additional sources.
+
+These changes open up the way towards changes like a fixed partition scheme, high-performance storage formats and similar.

--- a/.claude/plans/stage-1-quick-wins.md
+++ b/.claude/plans/stage-1-quick-wins.md
@@ -1,0 +1,299 @@
+# Stage 1: Quick Wins — Faster Watch, Leaner Builds
+
+## Goal
+
+Eliminate full image rebuilds on every code change during `docker compose watch`, reduce build context size, harden the uv dependency caching in Dockerfiles, and fix misleading comments. Expected impact: code change → running code server in **seconds** instead of **minutes**.
+
+---
+
+## 1.1 Switch watch rules from `rebuild` to `sync+restart`
+
+### Background
+
+The compose.yaml comment (lines 97-102) claims `DockerRunLauncher` is in use, but `docker/dagster/dagster.yaml` (line 7) actually configures `DefaultRunLauncher`. With `DefaultRunLauncher` + gRPC code servers, runs execute as subprocesses spawned by the gRPC code server process — not as new Docker containers from the image. Therefore `action: sync+restart` is sufficient: sync the changed files into the running container, restart the code server process, and new runs use the updated code.
+
+### Changes to `docker/compose.yaml`
+
+For each of `bag3d-core`, `bag3d-floors-estimation`, `bag3d-party-walls`, replace the `develop.watch` block. Use `sync+restart` for source directories, and `rebuild` only for dependency metadata files (pyproject.toml, uv.lock) that require a `uv sync` inside the container.
+
+**bag3d-core** (replace lines 103-116):
+```yaml
+    develop:
+      watch:
+        - action: sync+restart
+          path: ../packages/common/src
+          target: /opt/3dbag-pipeline/packages/common/src
+        - action: sync+restart
+          path: ../packages/core/src
+          target: /opt/3dbag-pipeline/packages/core/src
+        - action: rebuild
+          path: ../packages/common/pyproject.toml
+          target: /opt/3dbag-pipeline/packages/common/pyproject.toml
+        - action: rebuild
+          path: ../packages/core/pyproject.toml
+          target: /opt/3dbag-pipeline/packages/core/pyproject.toml
+        - action: rebuild
+          path: ../packages/core/uv.lock
+          target: /opt/3dbag-pipeline/packages/core/uv.lock
+```
+
+**bag3d-floors-estimation** (replace lines 147-160):
+```yaml
+    develop:
+      watch:
+        - action: sync+restart
+          path: ../packages/common/src
+          target: /opt/3dbag-pipeline/packages/common/src
+        - action: sync+restart
+          path: ../packages/floors_estimation/src
+          target: /opt/3dbag-pipeline/packages/floors_estimation/src
+        - action: rebuild
+          path: ../packages/common/pyproject.toml
+          target: /opt/3dbag-pipeline/packages/common/pyproject.toml
+        - action: rebuild
+          path: ../packages/floors_estimation/pyproject.toml
+          target: /opt/3dbag-pipeline/packages/floors_estimation/pyproject.toml
+        - action: rebuild
+          path: ../packages/floors_estimation/uv.lock
+          target: /opt/3dbag-pipeline/packages/floors_estimation/uv.lock
+```
+
+**bag3d-party-walls** (replace lines 191-204):
+```yaml
+    develop:
+      watch:
+        - action: sync+restart
+          path: ../packages/common/src
+          target: /opt/3dbag-pipeline/packages/common/src
+        - action: sync+restart
+          path: ../packages/party_walls/src
+          target: /opt/3dbag-pipeline/packages/party_walls/src
+        - action: rebuild
+          path: ../packages/common/pyproject.toml
+          target: /opt/3dbag-pipeline/packages/common/pyproject.toml
+        - action: rebuild
+          path: ../packages/party_walls/pyproject.toml
+          target: /opt/3dbag-pipeline/packages/party_walls/pyproject.toml
+        - action: rebuild
+          path: ../packages/party_walls/uv.lock
+          target: /opt/3dbag-pipeline/packages/party_walls/uv.lock
+```
+
+### Why only `src/` directories?
+
+Watching `../packages/core` (the whole package dir) would also trigger on test file changes, README changes, etc. Watching `src/` only triggers on actual source code changes that the code server needs.
+
+---
+
+## 1.2 Fix the outdated DockerRunLauncher comment
+
+### Change in `docker/compose.yaml`
+
+Replace lines 97-102 (the comment block above `develop:` in `bag3d-core`) with:
+
+```yaml
+    # docker compose watch: sync+restart syncs changed source files into the
+    # running container and restarts the gRPC code server. Since we use
+    # DefaultRunLauncher, runs execute as subprocesses of the code server, so
+    # they pick up the synced code. Dependency file changes (pyproject.toml,
+    # uv.lock) still trigger a full rebuild since they require uv sync.
+```
+
+---
+
+## 1.3 Targeted COPY in Dockerfiles
+
+### Current problem
+
+`COPY . $BAG3D_PIPELINE_LOCATION` copies the entire repo (filtered by `.dockerignore`). A change to `packages/party_walls/` invalidates the `bag3d-core` image layer cache even though core doesn't use party_walls code.
+
+### Changes
+
+**`docker/pipeline/bag3d-core.dockerfile`** — replace line 28:
+```dockerfile
+# Before:
+# COPY . $BAG3D_PIPELINE_LOCATION
+
+# After:
+COPY packages/common $BAG3D_PIPELINE_LOCATION/packages/common
+COPY packages/core $BAG3D_PIPELINE_LOCATION/packages/core
+```
+
+**`docker/pipeline/bag3d-floors-estimation.dockerfile`** — replace line 28:
+```dockerfile
+COPY packages/common $BAG3D_PIPELINE_LOCATION/packages/common
+COPY packages/floors_estimation $BAG3D_PIPELINE_LOCATION/packages/floors_estimation
+```
+
+**`docker/pipeline/bag3d-party-walls.dockerfile`** — replace line 41:
+```dockerfile
+COPY packages/common $BAG3D_PIPELINE_LOCATION/packages/common
+COPY packages/party_walls $BAG3D_PIPELINE_LOCATION/packages/party_walls
+```
+
+### Caveat
+
+The `uv sync` step after COPY uses the lock file at `$BAG3D_PIPELINE_LOCATION/packages/<pkg>/uv.lock`. Since we're copying the whole package directory, the `uv.lock` and `pyproject.toml` are included. The `bag3d-common` dependency is a `path = "../common"` reference in pyproject.toml, so `packages/common` must also be copied. This is already covered above.
+
+---
+
+## 1.4 Harden the uv dependency caching in Dockerfiles
+
+### Analysis of the current two-step caching strategy
+
+The Dockerfiles use a well-designed two-step `uv sync` pattern:
+
+**Step 1 — dependency-only install (layer-cached by lock/pyproject content):**
+```dockerfile
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=./packages/core/uv.lock,target=.../uv.lock \
+    --mount=type=bind,source=./packages/core/pyproject.toml,target=.../pyproject.toml \
+    uv sync --frozen --all-extras --no-install-project --no-install-package bag3d-common \
+    --project .../packages/core --python $VIRTUAL_ENV/bin/python
+```
+
+**Step 2 — full source copy (always invalidated by code changes):**
+```dockerfile
+COPY . $BAG3D_PIPELINE_LOCATION
+```
+
+**Step 3 — project install (cheap, just editable `.pth` links):**
+```dockerfile
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --all-extras \
+    --project .../packages/core --python $VIRTUAL_ENV/bin/python
+```
+
+This is the correct uv Docker caching pattern. How the caching layers interact:
+
+- **Docker layer cache:** BuildKit hashes the bind-mounted file contents (`uv.lock`, `pyproject.toml`) as part of the layer cache key. If these files haven't changed, Step 1 is skipped entirely (layer reused). Step 3 always re-runs after COPY, but it's fast because all third-party deps are already installed.
+- **BuildKit cache mount (`/root/.cache/uv`):** Persists across builds. Even when Step 1's layer IS invalidated (lock/pyproject changed), uv doesn't re-download packages that are already in this cache. All three pipeline images share this cache (same mount target), which is correct — they share most dependencies.
+- **`--frozen`:** Prevents resolution. Reads the lockfile directly. Doesn't try to re-resolve sources or access the network.
+- **`--no-install-package bag3d-common`:** Skips installing bag3d-common, but its transitive dependencies (docker, requests, fabric, psycopg, etc.) ARE installed because they're listed as independent packages in the lockfile.
+
+### Issue: Missing bind-mount for `packages/common/pyproject.toml`
+
+The lockfile for each package has `bag3d-common` declared as `source = { editable = "../common" }`. In Step 1, only the package's own `uv.lock` and `pyproject.toml` are bind-mounted — `packages/common/pyproject.toml` doesn't exist in the container at this point.
+
+Currently this works because `--frozen` + `--no-install-package bag3d-common` means uv skips this package entirely without trying to read its source directory. However, this is **fragile**: a future uv version could validate editable source paths even when skipping install, or the behavior of `--frozen` with missing workspace members could change.
+
+**Fix:** Add a bind-mount for common's `pyproject.toml` in Step 1 of all three Dockerfiles. This doesn't affect cache behavior (common's pyproject.toml changes very rarely, and only adds a second file to the cache key hash).
+
+**`docker/pipeline/bag3d-core.dockerfile`** — replace lines 17-26:
+```dockerfile
+# Install only third-party dependencies (layer cached by lock/pyproject content)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=./packages/core/uv.lock,target=$BAG3D_PIPELINE_LOCATION/packages/core/uv.lock \
+    --mount=type=bind,source=./packages/core/pyproject.toml,target=$BAG3D_PIPELINE_LOCATION/packages/core/pyproject.toml \
+    --mount=type=bind,source=./packages/common/pyproject.toml,target=$BAG3D_PIPELINE_LOCATION/packages/common/pyproject.toml \
+    uv sync \
+    --frozen \
+    --all-extras \
+    --no-install-project \
+    --no-install-package bag3d-common \
+    --project $BAG3D_PIPELINE_LOCATION/packages/core \
+    --python $VIRTUAL_ENV/bin/python
+```
+
+**`docker/pipeline/bag3d-floors-estimation.dockerfile`** — same pattern:
+```dockerfile
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=./packages/floors_estimation/uv.lock,target=$BAG3D_PIPELINE_LOCATION/packages/floors_estimation/uv.lock \
+    --mount=type=bind,source=./packages/floors_estimation/pyproject.toml,target=$BAG3D_PIPELINE_LOCATION/packages/floors_estimation/pyproject.toml \
+    --mount=type=bind,source=./packages/common/pyproject.toml,target=$BAG3D_PIPELINE_LOCATION/packages/common/pyproject.toml \
+    uv sync \
+    --frozen \
+    --all-extras \
+    --no-install-project \
+    --no-install-package bag3d-common \
+    --project $BAG3D_PIPELINE_LOCATION/packages/floors_estimation \
+    --python $VIRTUAL_ENV/bin/python
+```
+
+**`docker/pipeline/bag3d-party-walls.dockerfile`** — same pattern:
+```dockerfile
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=./packages/party_walls/uv.lock,target=$BAG3D_PIPELINE_LOCATION/packages/party_walls/uv.lock \
+    --mount=type=bind,source=./packages/party_walls/pyproject.toml,target=$BAG3D_PIPELINE_LOCATION/packages/party_walls/pyproject.toml \
+    --mount=type=bind,source=./packages/common/pyproject.toml,target=$BAG3D_PIPELINE_LOCATION/packages/common/pyproject.toml \
+    uv sync \
+    --frozen \
+    --all-extras \
+    --no-install-project \
+    --no-install-package bag3d-common \
+    --project $BAG3D_PIPELINE_LOCATION/packages/party_walls \
+    --python $VIRTUAL_ENV/bin/python
+```
+
+### Note: unbounded uv cache growth
+
+The `--mount=type=cache,target=/root/.cache/uv` BuildKit cache mount grows over time as package versions change. Old versions are never cleaned. This is one contributor to "excessive docker cache use."
+
+To periodically clean it:
+```bash
+# Remove all BuildKit cache mounts
+docker builder prune --filter type=exec.cachemount
+
+# Or more aggressively, all BuildKit cache
+docker builder prune --all
+```
+
+Consider adding a `make docker_prune_cache` target for this.
+
+---
+
+## 1.5 Expand `.dockerignore`
+
+### Additions to `.dockerignore`
+
+```
+# Docker config (not needed inside pipeline images)
+docker/
+
+# Git and GitHub
+.git/
+.github/
+
+# Root config files not needed in images
+makefile
+tools-build.sh
+tools-test.sh
+mkdocs.yml
+CHANGELOG.md
+LICENSE-*
+README.md
+CLAUDE.md
+pyproject.toml
+uv.lock
+
+# Per-package local venvs
+packages/*/.venv
+```
+
+### Note
+
+The root `pyproject.toml` and `uv.lock` are for the dev workspace only — not used by the pipeline Dockerfiles (they each reference `packages/<pkg>/pyproject.toml`). The per-package `.venv` directories created by `make local_venv` can also be excluded.
+
+### Interaction with targeted COPY (1.3)
+
+With the targeted COPY approach from 1.3, the `.dockerignore` becomes less critical for excluding unrelated packages (since they're not copied anyway). However, it still reduces the **build context transfer size** — Docker sends the entire context to the daemon before builds begin, and `.dockerignore` controls what's included in that transfer. Excluding `.git/` alone can save hundreds of MB.
+
+---
+
+## Verification
+
+1. Run `make docker_up` to build images with the updated Dockerfiles (one-time build)
+2. Run `make docker_watch` to start compose watch
+3. Edit a Python file in `packages/core/src/bag3d/core/` (e.g., add a log statement to an asset)
+4. Observe the watch output: should show `Syncing...` and `Restarting...` (not `Rebuilding...`)
+5. Check the Dagster UI at http://localhost:3003 — the code location should reload within seconds
+6. Launch a test run in the UI and verify the log statement appears (confirming the synced code is used)
+7. Edit `packages/core/pyproject.toml` (e.g., add a comment) — verify this triggers a full rebuild
+8. Run `make test` to verify tests still pass with the targeted COPY approach
+
+### Verify uv caching effectiveness
+
+9. After the initial build, run `make docker_build` (no-cache build) and note the total build time
+10. Change a single file in `packages/core/src/`, run `docker compose -p bag3d-dev -f docker/compose.yaml build bag3d-core` — Step 1 should be cached (instant), only COPY + Step 3 re-run
+11. Change `packages/core/pyproject.toml`, run the same build — Step 1 should re-run (but fast due to uv download cache), then COPY + Step 3
+12. Change a file in `packages/party_walls/src/`, build `bag3d-core` — with targeted COPY, the core image should be fully cached (no layers re-run)

--- a/.claude/plans/stage-2-dev-overlay-and-ide.md
+++ b/.claude/plans/stage-2-dev-overlay-and-ide.md
@@ -1,0 +1,174 @@
+# Stage 2: Dev Compose Overlay and IDE Integration
+
+## Goal
+
+Create a development-specific compose override that bind-mounts source code (eliminating even the sync step), exposes the Docker socket to pipeline containers (prerequisite for Stage 3), and documents a PyCharm setup that works for both code analysis and in-container test execution.
+
+---
+
+## 2.1 Create `docker/compose.dev.yaml`
+
+A development overlay that layers on top of the base `docker/compose.yaml`. The key additions:
+
+1. **Bind-mount source code** — replaces the baked-in `/opt/3dbag-pipeline/packages/` with the host's live source. Edits are visible instantly, no sync or rebuild needed.
+2. **Mount Docker socket** on pipeline containers — needed for Stage 3 (running tools in standalone containers from within asset code).
+3. **Optional: profiles for selective startup** — let developers start only the services they need.
+
+### File: `docker/compose.dev.yaml`
+
+```yaml
+services:
+  bag3d-core:
+    volumes:
+      - bag3d-data-pipeline:/data/volume
+      - bag3d-dagster-home:/opt/dagster/dagster_home
+      - ~/.ssh:/root/.ssh:ro
+      # Bind-mount source for live editing
+      - ../packages/common/src:/opt/3dbag-pipeline/packages/common/src
+      - ../packages/core/src:/opt/3dbag-pipeline/packages/core/src
+      # Docker socket for running tools in standalone containers (Stage 3)
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  bag3d-floors-estimation:
+    volumes:
+      - bag3d-data-pipeline:/data/volume
+      - bag3d-dagster-home:/opt/dagster/dagster_home
+      - ../packages/common/src:/opt/3dbag-pipeline/packages/common/src
+      - ../packages/floors_estimation/src:/opt/3dbag-pipeline/packages/floors_estimation/src
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  bag3d-party-walls:
+    volumes:
+      - bag3d-data-pipeline:/data/volume
+      - bag3d-dagster-home:/opt/dagster/dagster_home
+      - ../packages/common/src:/opt/3dbag-pipeline/packages/common/src
+      - ../packages/party_walls/src:/opt/3dbag-pipeline/packages/party_walls/src
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+### Important: volumes key behavior
+
+The `volumes` key in the overlay **replaces** the base service's volumes list (compose merge behavior for lists). So we must repeat the base volumes (`bag3d-data-pipeline`, `bag3d-dagster-home`, `~/.ssh`) in addition to the new bind-mounts. Alternatively, we can use the `!override` YAML tag (already used in compose-prod.yaml) for explicit intent.
+
+---
+
+## 2.2 Update makefile targets
+
+### New targets in `makefile`
+
+```makefile
+# Development with bind-mounted source (instant code changes, no sync/rebuild)
+docker_dev:
+	BAG3D_DOCKER_IMAGE_TAG=$(BAG3D_DOCKER_IMAGE_TAG) docker compose -p $(COMPOSE_PROJECT_NAME) \
+		-f docker/compose.yaml -f docker/compose.dev.yaml up -d
+
+# Development with file watching (sync+restart on changes)
+docker_watch:
+	BAG3D_DOCKER_IMAGE_TAG=$(BAG3D_DOCKER_IMAGE_TAG) docker compose -p $(COMPOSE_PROJECT_NAME) \
+		-f docker/compose.yaml watch
+```
+
+The existing `docker_watch` target stays as-is (uses Stage 1 sync+restart). The new `docker_dev` target uses bind-mounts for an even faster workflow — edit files on the host, they're immediately visible in the container (though the gRPC code server may need a manual reload via the Dagster UI "Reload" button, or a container restart).
+
+### Update test targets to support the dev overlay
+
+The `make test` targets use `docker compose exec` which works the same regardless of whether bind-mounts or baked-in code is used. No changes needed for test targets.
+
+---
+
+## 2.3 Code server auto-reload with bind mounts
+
+With bind-mounted source, Dagster's gRPC code server doesn't automatically detect file changes (unlike `docker compose watch` which triggers a restart). Two options:
+
+**Option A: Manual reload** — Click "Reload" in the Dagster UI after editing code. Simple but requires a manual step.
+
+**Option B: watchfiles-based auto-restart** — Override the CMD in the dev overlay to wrap the dagster code-server with a file watcher:
+
+```yaml
+  bag3d-core:
+    # ... volumes ...
+    command: >
+      watchmedo auto-restart --directory=/opt/3dbag-pipeline/packages/core/src
+      --directory=/opt/3dbag-pipeline/packages/common/src --recursive --pattern="*.py"
+      -- dagster code-server start -h 0.0.0.0 -p 4000 -m bag3d.core.code_location
+```
+
+This requires `watchdog` to be installed in the container (`pip install watchdog`). It would need to be added to the tools requirements or installed in the dev overlay via entrypoint.
+
+**Recommendation:** Start with Option A (manual reload). It's simple and doesn't add dependencies. The `docker compose watch` with `sync+restart` from Stage 1 already handles auto-restart for the watch workflow.
+
+---
+
+## 2.4 PyCharm setup documentation
+
+### The two-environment problem
+
+- **Code analysis** (autocompletion, type checking, go-to-definition): needs a Python interpreter with all packages installed
+- **Test execution / debugging**: needs the Docker environment (database, tools, env vars)
+
+### Recommended setup
+
+#### For code analysis: local venv
+
+1. Run `make local_venv` to create per-package venvs
+2. In PyCharm, go to `Settings > Project > Python Interpreter`
+3. Add the venv for the package you're working on:
+   - For core: `packages/core/.venv/bin/python`
+   - For common: use core's venv (common is installed as editable dependency)
+4. Mark source roots: `packages/core/src`, `packages/common/src`
+
+This gives full autocompletion and type checking for all Python code. External tool binaries (roofer, tyler, etc.) aren't needed for code analysis.
+
+#### For test execution: Docker Compose interpreter
+
+1. In PyCharm, go to `Settings > Project > Python Interpreter > Add Interpreter > Docker Compose`
+2. Configuration file: `docker/compose.yaml` (optionally add `docker/compose.dev.yaml`)
+3. Service: `bag3d-core` (or the package you're working on)
+4. Python path: `/opt/3dbag-pipeline/venv/bin/python`
+5. Set path mappings: `<project-root>/packages → /opt/3dbag-pipeline/packages`
+
+With the dev overlay (bind-mounted source), PyCharm executes tests inside the container but uses your local source files — so breakpoints and debugging work correctly.
+
+#### Alternative: single interpreter with Remote Interpreter plugin
+
+PyCharm Professional's "Docker Compose" interpreter can be set as the project default. It runs code analysis by indexing the remote interpreter's packages. This is slower than a local venv but avoids maintaining two environments.
+
+### Where to document
+
+Add a `docs/development/pycharm-setup.md` or add a section to the existing development documentation. Also add a brief note in `CLAUDE.md` under "Development Commands".
+
+---
+
+## 2.5 Selective service startup with profiles
+
+For developers working on a single package, starting all three pipeline containers is wasteful. Add profiles to the compose overlay:
+
+```yaml
+services:
+  bag3d-floors-estimation:
+    profiles:
+      - floors
+      - all
+
+  bag3d-party-walls:
+    profiles:
+      - party-walls
+      - all
+```
+
+Then:
+- `docker compose ... up -d` starts only core + databases + dagster (no floors/party-walls)
+- `docker compose ... --profile floors up -d` also starts floors_estimation
+- `docker compose ... --profile all up -d` starts everything
+
+This is optional and can be added later if the full startup time is bothersome.
+
+---
+
+## Verification
+
+1. Run `make docker_dev` — verify containers start with bind-mounted source
+2. Edit a Python file on the host → verify the change is visible inside the container (`docker compose exec bag3d-core cat /opt/3dbag-pipeline/packages/core/src/bag3d/core/...`)
+3. Click "Reload" in Dagster UI → verify the code location reloads with the change
+4. Run `make test` → verify tests pass with bind-mounted source
+5. Configure PyCharm Docker Compose interpreter → run a single test with a breakpoint → verify debugging works

--- a/.claude/plans/stage-3-standalone-tool-containers.md
+++ b/.claude/plans/stage-3-standalone-tool-containers.md
@@ -136,7 +136,7 @@ Tyler calls geoflow via `--exe-geof <path>`. In the current setup, both binaries
 
 **Option B: Tyler container mounts geoflow from a shared volume.** Install geoflow into a named volume, mount it into the tyler container. More complex but keeps images independent.
 
-**Recommendation:** Option A. Tyler and geoflow are tightly coupled (tyler invokes geoflow per-tile). The combined image is still small compared to the current tools image.
+**Decision:** Option A. Tyler and geoflow are tightly coupled (tyler invokes geoflow per-tile). The combined image is still small compared to the current tools image.
 
 ### 3.4 Handle validation tools in ProcessPoolExecutor
 

--- a/.claude/plans/stage-3-standalone-tool-containers.md
+++ b/.claude/plans/stage-3-standalone-tool-containers.md
@@ -1,0 +1,313 @@
+# Stage 3: Run Tools in Standalone Docker Containers
+
+## Goal
+
+Decouple external tools (roofer, tyler, GDAL, PDAL, LAStools, val3dity, cjval, geoflow) from the pipeline images. Each tool runs in its own lightweight Docker container, invoked from within asset code via the Docker API. This eliminates the 3GB+ `3dbag-pipeline-tools` base image, dramatically reduces build times, and makes tool version management explicit.
+
+---
+
+## Current State
+
+### How tools are invoked today
+
+All tool calls go through `CommandRunner` in `packages/common/src/bag3d/common/resources/executables.py`:
+
+```
+Asset → Resource.runner → CommandRunner.run(cmd_template, exe_name, local_path, ...)
+  → _run_with_logging()  [subprocess.Popen, shell=True]
+  or → _run_docker()      [docker SDK, only for GDAL/PDAL when exe paths not set]
+```
+
+The `_run_docker()` backend (line 171) already exists and works for GDAL and PDAL. It uses `docker.from_env()`, `client.containers.run(image, command, detach=True, network_mode="host", volumes={...})`, waits for exit, reads logs, and removes the container.
+
+### Key patterns in asset code
+
+- Commands are shell strings with `{exe}` and `{local_path}` placeholders
+- Database connections are passed as `PG:"<dsn>"` in command arguments
+- Env vars (e.g., `RAYON_NUM_THREADS`) are prepended to the command string
+- File paths reference the container filesystem (`/data/volume/...`)
+- Some tools reference other tools' paths (tyler calls geoflow via `--exe-geof`)
+- Validation tools run in a `ProcessPoolExecutor` without Dagster logger
+
+### Tool images available
+
+| Tool | Existing Docker image | Currently compiled from source? |
+|---|---|---|
+| roofer | `3dgi/roofer:develop` | No (copied from image in tools Dockerfile) |
+| tyler | `3dgi/tyler:0.3.14` | No (copied from image) |
+| tyler-multiformat | `3dgi/tyler-multiformat:0.4.0-alpha10` | No (copied from image) |
+| tyler-db | `3dgi/tyler-db:0.3.4-db-alpha5` | No (copied from image) |
+| GDAL/ogr2ogr | `ghcr.io/osgeo/gdal:ubuntu-small-latest` | Yes (compiled in tools) |
+| PDAL | `pdal/pdal:sha-cfa827b6` | Yes (compiled in tools) |
+| LAStools | — | Yes (compiled in tools) |
+| val3dity | — | Yes (compiled in tools) |
+| cjval | `tudelft3d/cjval:0.8.2` | No (copied from image) |
+| cjio | — | Yes (pip installed in tools) |
+| geoflow | `3dgi/geoflow-bundle-builder:2025.09.01` | No (copied from image) |
+
+---
+
+## Prerequisites
+
+### 3.0a Check PipesDockerClient log forwarding in dagster 1.12
+
+**What:** Test whether `dagster.PipesDockerClient` in dagster 1.12 properly forwards container stdout/stderr to Dagster logs. The user reported this was broken in dagster 1.9 (libs 0.25).
+
+**How:**
+1. Create a test asset that uses `PipesDockerClient` to run a simple container (e.g., `alpine echo "hello"`)
+2. Materialize it in the Dagster UI
+3. Check if "hello" appears in the structured event logs (not just compute logs)
+4. Test with a multi-line output and stderr to verify completeness
+
+**Decision point:** If PipesDockerClient works, use it as the primary interface (better Dagster integration, structured logging). If not, continue using the `docker` SDK directly via `CommandRunner._run_docker()`.
+
+### 3.0b Docker socket on pipeline containers
+
+The pipeline containers need access to the host Docker socket to launch tool containers. This requires:
+
+```yaml
+volumes:
+  - /var/run/docker.sock:/var/run/docker.sock
+```
+
+This is already done in Stage 2's `compose.dev.yaml`. For production, the compose-prod.yaml overlay also needs this mount on `bag3d-core` (it's currently only on webserver/daemon).
+
+### 3.0c Configurable network and volume names
+
+Tool containers need to join the same Docker network and mount the same data volume as the pipeline containers. These names are already in env vars (`BAG3D_DOCKER_NETWORK`, `BAG3D_DOCKER_VOLUME_DATA_PIPELINE`) and must be passed through to the Docker API calls.
+
+---
+
+## Implementation Plan
+
+### 3.1 Extend `CommandRunner._run_docker()` to be the general tool execution path
+
+**File:** `packages/common/src/bag3d/common/resources/executables.py`
+
+The existing `_run_docker()` method (line 171) is already functional but limited. Extend it:
+
+```python
+@dataclass(frozen=True)
+class DockerConfig:
+    """Configuration for running a tool in a Docker container."""
+    image: str
+    network: str | None = None          # Docker network to join
+    volumes: dict[str, dict] | None = None  # {host_path_or_volume: {"bind": path, "mode": "rw"}}
+    environment: dict[str, str] | None = None  # env vars for the container
+    working_dir: str | None = None
+```
+
+Changes to `_run_docker()`:
+- Accept `network` parameter (currently hardcoded to `network_mode="host"`) — use env var `BAG3D_DOCKER_NETWORK` as default
+- Accept `volumes` parameter — default to mounting `BAG3D_DOCKER_VOLUME_DATA_PIPELINE` at `/data/volume`
+- Accept `environment` parameter — for tool-specific env vars like `RAYON_NUM_THREADS`
+- Forward stdout/stderr to Dagster logger in real-time (stream container logs instead of reading after exit)
+- Add timeout support
+
+### 3.2 Make each tool resource support Docker mode
+
+Currently only `GDALResource` and `PDALResource` have Docker image config. Extend all resource classes with optional Docker image fields:
+
+```python
+class RooferResource(ConfigurableResource):
+    exe_roofer: str = ""
+    exe_crop: str = ""
+    # New: Docker mode config
+    docker_image: str = "3dgi/roofer:develop"
+    docker_enabled: bool = False
+
+    @property
+    def runner(self) -> CommandRunner:
+        if self.docker_enabled:
+            return CommandRunner(
+                exes={"roofer": "roofer", "crop": "crop"},  # in-container paths
+                docker_config=DockerConfig(image=self.docker_image),
+            )
+        return CommandRunner(exes={"roofer": self.exe_roofer, "crop": self.exe_crop})
+```
+
+The `docker_enabled` flag lets us gradually migrate tool by tool. When enabled, `exe_name` maps to the in-container binary path, and `local_path` is volume-mounted.
+
+### 3.3 Handle the tyler + geoflow cross-tool dependency
+
+Tyler calls geoflow via `--exe-geof <path>`. In the current setup, both binaries exist in the same container. With standalone containers, two approaches:
+
+**Option A: Bundle tyler + geoflow in the same container.** Create a `3dgi/tyler-bundle` image that includes both tyler and geoflow. This is the simplest approach and preserves the current command structure.
+
+**Option B: Tyler container mounts geoflow from a shared volume.** Install geoflow into a named volume, mount it into the tyler container. More complex but keeps images independent.
+
+**Recommendation:** Option A. Tyler and geoflow are tightly coupled (tyler invokes geoflow per-tile). The combined image is still small compared to the current tools image.
+
+### 3.4 Handle validation tools in ProcessPoolExecutor
+
+The `check_formats()` function in `packages/core/src/bag3d/core/assets/export/validate.py` runs val3dity, cjval, and cjio in a `ProcessPoolExecutor` with a bare `CommandRunner()` (no Dagster logger). When switching to Docker mode:
+
+- The `CommandRunner._run_docker()` path doesn't need a Dagster logger — it can collect stdout/stderr and return them in `CommandResult`
+- The ProcessPoolExecutor pattern still works: each worker process creates its own Docker client and launches a container
+- May need to limit concurrency to avoid overwhelming the Docker daemon (too many simultaneous containers)
+
+### 3.5 Create lightweight pipeline base image
+
+Once tools are no longer bundled, the pipeline images don't need the 3GB `3dbag-pipeline-tools` base. Create a new lightweight base:
+
+**`docker/pipeline/base.dockerfile`:**
+```dockerfile
+FROM python:3.12-slim
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:0.8.2 /uv /usr/local/bin/uv
+
+# Install system dependencies needed by Python packages (psycopg, lxml, etc.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq-dev \
+    libxml2-dev \
+    libxslt-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG BAG3D_PIPELINE_LOCATION=/opt/3dbag-pipeline
+ENV VIRTUAL_ENV=$BAG3D_PIPELINE_LOCATION/venv
+RUN uv venv --python 3.12 $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV DAGSTER_HOME=/opt/dagster/dagster_home/
+
+# Install dagster
+COPY docker/tools/requirements.txt /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install -r /tmp/requirements.txt
+```
+
+This image would be ~200-300MB instead of 3GB+. The pipeline Dockerfiles would change their `FROM` line:
+
+```dockerfile
+# Before:
+FROM 3dgi/3dbag-pipeline-tools:2026.02.13 AS develop
+
+# After:
+FROM 3dgi/3dbag-pipeline-base:2026.xx.xx AS develop
+```
+
+### 3.6 Environment variable configuration for Docker tool execution
+
+Add new env vars to `docker/.env`:
+
+```ini
+# Tool execution mode: "local" (subprocess) or "docker" (standalone containers)
+BAG3D_TOOL_EXECUTION_MODE=local
+
+# Docker images for tools (used when BAG3D_TOOL_EXECUTION_MODE=docker)
+BAG3D_DOCKER_IMAGE_ROOFER=3dgi/roofer:develop
+BAG3D_DOCKER_IMAGE_TYLER=3dgi/tyler:0.3.14
+BAG3D_DOCKER_IMAGE_TYLER_MULTIFORMAT=3dgi/tyler-multiformat:0.4.0-alpha10
+BAG3D_DOCKER_IMAGE_TYLER_DB=3dgi/tyler-db:0.3.4-db-alpha5
+BAG3D_DOCKER_IMAGE_GDAL=ghcr.io/osgeo/gdal:ubuntu-small-3.8.5
+BAG3D_DOCKER_IMAGE_PDAL=pdal/pdal:2.8.4
+BAG3D_DOCKER_IMAGE_CJVAL=tudelft3d/cjval:0.8.2
+BAG3D_DOCKER_IMAGE_GEOFLOW=3dgi/geoflow-bundle-builder:2025.09.01
+```
+
+Resource configuration in `code_location.py` reads these and configures `docker_enabled` + `docker_image` on each tool resource.
+
+---
+
+## Migration Strategy: Tool by Tool
+
+Don't migrate all tools at once. Migrate one at a time, validate, then proceed:
+
+### Phase A: GDAL/ogr2ogr (already partially supported)
+
+`_run_docker()` already works for GDAL. Validate that:
+- BGT load (`assets/bgt/load.py`) works with Docker GDAL
+- BAG load (`assets/bag/load.py`) works with Docker GDAL
+- sozip export works with Docker GDAL
+- `PG:"<dsn>"` connections work from within the tool container (network access to `data-postgresql`)
+
+### Phase B: PDAL (already partially supported)
+
+Validate that:
+- AHN metadata extraction (`assets/ahn/metadata.py`) works with Docker PDAL
+- LAStools operations (lasindex, las2las, lasinfo) — these don't have official images. Either create a small `3dgi/lastools` image or keep them compiled in the base image.
+
+### Phase C: Roofer
+
+The most critical tool. Validate:
+- Reconstruction (`assets/reconstruction/reconstruction.py`) works with Docker roofer
+- TOML config file paths are correctly mapped
+- LAZ file paths (from database) are accessible from within the roofer container
+- Output directory is writable and accessible by the pipeline container after roofer exits
+
+### Phase D: Tyler + Geoflow bundle
+
+Create the combined tyler+geoflow image. Validate:
+- `TYLER_RESOURCES_DIR` and `GF_PLUGIN_FOLDER` are correctly set in the container
+- Environment vars (`RAYON_NUM_THREADS`, `RUST_LOG`) are passed through
+- Tyler's `--exe-geof` flag points to the geoflow binary inside the container
+
+### Phase E: Validation tools (val3dity, cjval, cjio)
+
+These run in ProcessPoolExecutor. Validate:
+- Concurrent container launches don't overwhelm Docker
+- stdout/stderr are correctly captured without Dagster logger
+- Performance is acceptable (container startup overhead × many validation runs)
+
+### Phase F: Remove tools from base image
+
+Once all tools are migrated:
+1. Switch pipeline Dockerfiles to the lightweight base image
+2. Remove the tools build from the `3dgi/3dbag-pipeline-tools` Dockerfile (or archive it)
+3. Update GH Actions workflows (build-docker-tools.yaml may become unnecessary)
+4. Update `EXE_PATH_*` env vars to be empty/removed when in Docker mode
+
+---
+
+## Key Files to Modify
+
+| File | Change |
+|---|---|
+| `packages/common/src/bag3d/common/resources/executables.py` | Extend `DockerConfig`, `CommandRunner._run_docker()`, all tool resources |
+| `packages/core/src/bag3d/core/code_location.py` | Resource configuration for Docker mode |
+| `packages/floors_estimation/src/bag3d/floors_estimation/code_location.py` | Same |
+| `packages/party_walls/src/bag3d/party_walls/code_location.py` | Same |
+| `docker/.env` | New `BAG3D_TOOL_EXECUTION_MODE` and `BAG3D_DOCKER_IMAGE_*` vars |
+| `docker/compose.yaml` | Docker socket mount on pipeline containers |
+| `docker/compose.dev.yaml` | Same |
+| `docker/pipeline/base.dockerfile` (new) | Lightweight Python-only base image |
+| `docker/pipeline/bag3d-core.dockerfile` | Change FROM to lightweight base |
+| `docker/pipeline/bag3d-floors-estimation.dockerfile` | Same |
+| `docker/pipeline/bag3d-party-walls.dockerfile` | Same |
+| Deployment compose overlays in `3dbag-admin` | Docker socket mount, tool image env vars |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Container startup overhead per tool call | Slower execution, especially for many small calls (validation) | Benchmark first; for high-frequency calls, consider keeping the tool in the base image |
+| Network connectivity between tool containers and data-postgresql | Tools can't access DB | Use `network` parameter to join `bag3d-network`; test PG connectivity from tool containers |
+| Volume mount path mapping complexity | Wrong file paths in tool commands | `CommandRunner._run_docker()` already handles path remapping; extend as needed |
+| Docker-in-Docker stability | Reliability issues | We're using Docker socket mounting (DooD), not nested Docker — this is well-supported |
+| Tyler+geoflow tight coupling | Complex container setup | Bundle in single image (Option A above) |
+| PipesDockerClient doesn't forward logs | No structured Dagster logging | Fall back to `docker` SDK with `_run_docker()` (already working) |
+
+---
+
+## Verification
+
+### Per-tool validation
+For each migrated tool:
+1. Run the corresponding `make test` target with `BAG3D_TOOL_EXECUTION_MODE=docker`
+2. Run the corresponding Dagster job in the UI and verify:
+   - Tool output appears in Dagster logs
+   - Output files are created correctly
+   - No file permission issues
+
+### End-to-end validation
+1. Run `make test_integration` with all tools in Docker mode
+2. Compare output artifacts with a baseline run using local tools
+3. Measure execution time overhead from container startup
+
+### Image size validation
+1. Build the lightweight base image: `docker build -f docker/pipeline/base.dockerfile -t 3dgi/3dbag-pipeline-base:test .`
+2. Build a pipeline image on top: `docker build -f docker/pipeline/bag3d-core.dockerfile -t test-core .`
+3. Compare `docker images` sizes: expect ~300MB vs current ~3.5GB
+4. Verify GH Actions build time for the pipeline images (should be minutes, not 30+)

--- a/.dockerignore
+++ b/.dockerignore
@@ -29,6 +29,7 @@ tests/dagster_home/storage/
 
 # Virtual envs
 venvs
+packages/*/.venv
 
 # Documentation
 **/site
@@ -38,6 +39,27 @@ venvs
 **/.tox
 **/.coverage
 **/*.ruff_cache
+
+# Docker config (not needed inside pipeline images)
+# Exception: docker/tools/requirements.txt is needed by bag3d-party-walls.dockerfile
+docker/
+!docker/tools/requirements.txt
+
+# Git and GitHub
+.git/
+.github/
+
+# Root config files not needed in images
+makefile
+tools-build.sh
+tools-test.sh
+mkdocs.yml
+CHANGELOG.md
+LICENSE-*
+README.md
+CLAUDE.md
+pyproject.toml
+uv.lock
 
 # Other
 experiments

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -1,0 +1,55 @@
+# Development overlay for docker/compose.yaml.
+#
+# Bind-mounts the host source directories into the containers so that edits
+# are immediately visible without a sync or rebuild step. Also mounts the
+# Docker socket on the pipeline containers (required for Stage 3: running
+# external tools in standalone containers from within asset code).
+#
+# Usage:
+#   docker compose -p bag3d-dev -f docker/compose.yaml -f docker/compose.dev.yaml up -d
+#   # or via make:
+#   make docker_dev
+#
+# After editing Python files, click "Reload" in the Dagster UI (http://localhost:3000)
+# to pick up the changes in the gRPC code server. The tests (make test) work
+# unchanged because they use `docker compose exec`.
+#
+# Profiles (optional, for selective startup):
+#   No profile  → starts core + databases + dagster only
+#   --profile floors      → also starts bag3d-floors-estimation
+#   --profile party-walls → also starts bag3d-party-walls
+#   --profile all         → starts everything
+
+services:
+  bag3d-core:
+    volumes:
+      - bag3d-data-pipeline:/data/volume
+      - bag3d-dagster-home:/opt/dagster/dagster_home
+      - ~/.ssh:/root/.ssh:ro
+      # Bind-mount source for live editing — changes visible instantly in the container
+      - ../packages/common/src:/opt/3dbag-pipeline/packages/common/src
+      - ../packages/core/src:/opt/3dbag-pipeline/packages/core/src
+      # Docker socket for running tools in standalone containers (Stage 3)
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  bag3d-floors-estimation:
+    profiles:
+      - floors
+      - all
+    volumes:
+      - bag3d-data-pipeline:/data/volume
+      - bag3d-dagster-home:/opt/dagster/dagster_home
+      - ../packages/common/src:/opt/3dbag-pipeline/packages/common/src
+      - ../packages/floors_estimation/src:/opt/3dbag-pipeline/packages/floors_estimation/src
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  bag3d-party-walls:
+    profiles:
+      - party-walls
+      - all
+    volumes:
+      - bag3d-data-pipeline:/data/volume
+      - bag3d-dagster-home:/opt/dagster/dagster_home
+      - ../packages/common/src:/opt/3dbag-pipeline/packages/common/src
+      - ../packages/party_walls/src:/opt/3dbag-pipeline/packages/party_walls/src
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -13,12 +13,6 @@
 # After editing Python files, click "Reload" in the Dagster UI (http://localhost:3000)
 # to pick up the changes in the gRPC code server. The tests (make test) work
 # unchanged because they use `docker compose exec`.
-#
-# Profiles (optional, for selective startup):
-#   No profile  → starts core + databases + dagster only
-#   --profile floors      → also starts bag3d-floors-estimation
-#   --profile party-walls → also starts bag3d-party-walls
-#   --profile all         → starts everything
 
 services:
   bag3d-core:
@@ -29,27 +23,27 @@ services:
       # Bind-mount source for live editing — changes visible instantly in the container
       - ../packages/common/src:/opt/3dbag-pipeline/packages/common/src
       - ../packages/core/src:/opt/3dbag-pipeline/packages/core/src
+      - ../packages/common/tests:/opt/3dbag-pipeline/packages/common/tests
+      - ../packages/core/tests:/opt/3dbag-pipeline/packages/core/tests
       # Docker socket for running tools in standalone containers (Stage 3)
       - /var/run/docker.sock:/var/run/docker.sock
 
   bag3d-floors-estimation:
-    profiles:
-      - floors
-      - all
     volumes:
       - bag3d-data-pipeline:/data/volume
       - bag3d-dagster-home:/opt/dagster/dagster_home
       - ../packages/common/src:/opt/3dbag-pipeline/packages/common/src
       - ../packages/floors_estimation/src:/opt/3dbag-pipeline/packages/floors_estimation/src
+      - ../packages/common/tests:/opt/3dbag-pipeline/packages/common/tests
+      - ../packages/floors_estimation/tests:/opt/3dbag-pipeline/packages/floors_estimation/tests
       - /var/run/docker.sock:/var/run/docker.sock
 
   bag3d-party-walls:
-    profiles:
-      - party-walls
-      - all
     volumes:
       - bag3d-data-pipeline:/data/volume
       - bag3d-dagster-home:/opt/dagster/dagster_home
       - ../packages/common/src:/opt/3dbag-pipeline/packages/common/src
       - ../packages/party_walls/src:/opt/3dbag-pipeline/packages/party_walls/src
+      - ../packages/common/tests:/opt/3dbag-pipeline/packages/common/tests
+      - ../packages/party_walls/tests:/opt/3dbag-pipeline/packages/party_walls/tests
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -107,6 +107,12 @@ services:
         - action: sync+restart
           path: ../packages/core/src
           target: /opt/3dbag-pipeline/packages/core/src
+        - action: sync+restart
+          path: ../packages/common/tests
+          target: /opt/3dbag-pipeline/packages/common/tests
+        - action: sync+restart
+          path: ../packages/core/tests
+          target: /opt/3dbag-pipeline/packages/core/tests
         - action: rebuild
           path: ../packages/common/pyproject.toml
           target: /opt/3dbag-pipeline/packages/common/pyproject.toml
@@ -154,6 +160,12 @@ services:
         - action: sync+restart
           path: ../packages/floors_estimation/src
           target: /opt/3dbag-pipeline/packages/floors_estimation/src
+        - action: sync+restart
+          path: ../packages/common/tests
+          target: /opt/3dbag-pipeline/packages/common/tests
+        - action: sync+restart
+          path: ../packages/floors_estimation/tests
+          target: /opt/3dbag-pipeline/packages/floors_estimation/tests
         - action: rebuild
           path: ../packages/common/pyproject.toml
           target: /opt/3dbag-pipeline/packages/common/pyproject.toml
@@ -201,6 +213,12 @@ services:
         - action: sync+restart
           path: ../packages/party_walls/src
           target: /opt/3dbag-pipeline/packages/party_walls/src
+        - action: sync+restart
+          path: ../packages/common/tests
+          target: /opt/3dbag-pipeline/packages/common/tests
+        - action: sync+restart
+          path: ../packages/party_walls/tests
+          target: /opt/3dbag-pipeline/packages/party_walls/tests
         - action: rebuild
           path: ../packages/common/pyproject.toml
           target: /opt/3dbag-pipeline/packages/common/pyproject.toml

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -94,26 +94,28 @@ services:
       data-postgresql:
         condition: service_healthy
         restart: true
-    # Normally we wouldn't need watch:action:rebuild, but because we are using
-    # dagster's DockerRunLauncher, it always starts a new container from the image, for
-    # each run. While, watch:action:sync (or sync+restart)copies the changed local code into the
-    # 3dbag-pipeline-core-develop container (not the image). But since DockerRunLauncher
-    # doesn't actually use this container, but always starts a new one, we have to build
-    # a new image on each change.
+    # docker compose watch: sync+restart syncs changed source files into the
+    # running container and restarts the gRPC code server. Since we use
+    # DefaultRunLauncher, runs execute as subprocesses of the code server, so
+    # they pick up the synced code. Dependency file changes (pyproject.toml,
+    # uv.lock) still trigger a full rebuild since they require uv sync.
     develop:
       watch:
-        - action: rebuild
-          path: ../packages/common
-          target: /opt/3dbag-pipeline/packages/common
+        - action: sync+restart
+          path: ../packages/common/src
+          target: /opt/3dbag-pipeline/packages/common/src
+        - action: sync+restart
+          path: ../packages/core/src
+          target: /opt/3dbag-pipeline/packages/core/src
         - action: rebuild
           path: ../packages/common/pyproject.toml
           target: /opt/3dbag-pipeline/packages/common/pyproject.toml
         - action: rebuild
-          path: ../packages/core
-          target: /opt/3dbag-pipeline/packages/core
-        - action: rebuild
           path: ../packages/core/pyproject.toml
           target: /opt/3dbag-pipeline/packages/core/pyproject.toml
+        - action: rebuild
+          path: ../packages/core/uv.lock
+          target: /opt/3dbag-pipeline/packages/core/uv.lock
 
   bag3d-floors-estimation:
     platform: linux/amd64
@@ -146,18 +148,21 @@ services:
         restart: true
     develop:
       watch:
-        - action: rebuild
-          path: ../packages/common
-          target: /opt/3dbag-pipeline/packages/common
+        - action: sync+restart
+          path: ../packages/common/src
+          target: /opt/3dbag-pipeline/packages/common/src
+        - action: sync+restart
+          path: ../packages/floors_estimation/src
+          target: /opt/3dbag-pipeline/packages/floors_estimation/src
         - action: rebuild
           path: ../packages/common/pyproject.toml
           target: /opt/3dbag-pipeline/packages/common/pyproject.toml
         - action: rebuild
-          path: ../packages/floors_estimation
-          target: /opt/3dbag-pipeline/packages/floors_estimation
-        - action: rebuild
           path: ../packages/floors_estimation/pyproject.toml
           target: /opt/3dbag-pipeline/packages/floors_estimation/pyproject.toml
+        - action: rebuild
+          path: ../packages/floors_estimation/uv.lock
+          target: /opt/3dbag-pipeline/packages/floors_estimation/uv.lock
 
   bag3d-party-walls:
     platform: linux/amd64
@@ -190,18 +195,21 @@ services:
         restart: true
     develop:
       watch:
-        - action: rebuild
-          path: ../packages/common
-          target: /opt/3dbag-pipeline/packages/common
+        - action: sync+restart
+          path: ../packages/common/src
+          target: /opt/3dbag-pipeline/packages/common/src
+        - action: sync+restart
+          path: ../packages/party_walls/src
+          target: /opt/3dbag-pipeline/packages/party_walls/src
         - action: rebuild
           path: ../packages/common/pyproject.toml
           target: /opt/3dbag-pipeline/packages/common/pyproject.toml
         - action: rebuild
-          path: ../packages/party_walls
-          target: /opt/3dbag-pipeline/packages/party_walls
-        - action: rebuild
           path: ../packages/party_walls/pyproject.toml
           target: /opt/3dbag-pipeline/packages/party_walls/pyproject.toml
+        - action: rebuild
+          path: ../packages/party_walls/uv.lock
+          target: /opt/3dbag-pipeline/packages/party_walls/uv.lock
 
   # This service runs dagster-webserver, which loads your user code from the user code container.
   # Since our instance uses the QueuedRunCoordinator, any runs submitted from the webserver will be put on

--- a/docker/pipeline/bag3d-core.dockerfile
+++ b/docker/pipeline/bag3d-core.dockerfile
@@ -13,19 +13,21 @@ WORKDIR $BAG3D_PIPELINE_LOCATION
 
 ENV UV_PROJECT_ENVIRONMENT=$VIRTUAL_ENV
 
-# Install only dependencies except the bag3d-common package
+# Install only third-party dependencies (layer cached by lock/pyproject content)
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=./packages/core/uv.lock,target=$BAG3D_PIPELINE_LOCATION/packages/core/uv.lock \
     --mount=type=bind,source=./packages/core/pyproject.toml,target=$BAG3D_PIPELINE_LOCATION/packages/core/pyproject.toml \
+    --mount=type=bind,source=./packages/common/pyproject.toml,target=$BAG3D_PIPELINE_LOCATION/packages/common/pyproject.toml \
     uv sync \
     --frozen \
     --all-extras \
     --no-install-project \
-    --no-install-package bag3d-common\
+    --no-install-package bag3d-common \
     --project $BAG3D_PIPELINE_LOCATION/packages/core \
     --python $VIRTUAL_ENV/bin/python
 
-COPY . $BAG3D_PIPELINE_LOCATION
+COPY packages/common $BAG3D_PIPELINE_LOCATION/packages/common
+COPY packages/core $BAG3D_PIPELINE_LOCATION/packages/core
 
 # Install the workflow package and the bag3d-common package in editable mode
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/docker/pipeline/bag3d-floors-estimation.dockerfile
+++ b/docker/pipeline/bag3d-floors-estimation.dockerfile
@@ -13,19 +13,21 @@ WORKDIR $BAG3D_PIPELINE_LOCATION
 
 ENV UV_PROJECT_ENVIRONMENT=$VIRTUAL_ENV
 
-# Install only dependencies except the bag3d-common package
+# Install only third-party dependencies (layer cached by lock/pyproject content)
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=./packages/floors_estimation/uv.lock,target=$BAG3D_PIPELINE_LOCATION/packages/floors_estimation/uv.lock \
     --mount=type=bind,source=./packages/floors_estimation/pyproject.toml,target=$BAG3D_PIPELINE_LOCATION/packages/floors_estimation/pyproject.toml \
+    --mount=type=bind,source=./packages/common/pyproject.toml,target=$BAG3D_PIPELINE_LOCATION/packages/common/pyproject.toml \
     uv sync \
     --frozen \
     --all-extras \
     --no-install-project \
-    --no-install-package bag3d-common\
+    --no-install-package bag3d-common \
     --project $BAG3D_PIPELINE_LOCATION/packages/floors_estimation \
     --python $VIRTUAL_ENV/bin/python
 
-COPY . $BAG3D_PIPELINE_LOCATION
+COPY packages/common $BAG3D_PIPELINE_LOCATION/packages/common
+COPY packages/floors_estimation $BAG3D_PIPELINE_LOCATION/packages/floors_estimation
 
 # Install the workflow package and the bag3d-common package in editable mode
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/docker/pipeline/bag3d-party-walls.dockerfile
+++ b/docker/pipeline/bag3d-party-walls.dockerfile
@@ -26,19 +26,21 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
 WORKDIR $BAG3D_PIPELINE_LOCATION
 
 
-# Install only dependencies except the bag3d-common package
+# Install only third-party dependencies (layer cached by lock/pyproject content)
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=./packages/party_walls/uv.lock,target=$BAG3D_PIPELINE_LOCATION/packages/party_walls/uv.lock \
     --mount=type=bind,source=./packages/party_walls/pyproject.toml,target=$BAG3D_PIPELINE_LOCATION/packages/party_walls/pyproject.toml \
+    --mount=type=bind,source=./packages/common/pyproject.toml,target=$BAG3D_PIPELINE_LOCATION/packages/common/pyproject.toml \
     uv sync \
     --frozen \
     --all-extras \
     --no-install-project \
-    --no-install-package bag3d-common\
+    --no-install-package bag3d-common \
     --project $BAG3D_PIPELINE_LOCATION/packages/party_walls \
     --python $VIRTUAL_ENV/bin/python
 
-COPY . $BAG3D_PIPELINE_LOCATION
+COPY packages/common $BAG3D_PIPELINE_LOCATION/packages/common
+COPY packages/party_walls $BAG3D_PIPELINE_LOCATION/packages/party_walls
 
 # Install the workflow package and the bag3d-common package in editable mode
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -3,3 +3,4 @@ The following sections describe how to get started with contributing to the 3dba
 - For setting up your environment and running the tests please have a look at our [code section](code.md)
 - For information about how to submit a contribution please have a look at our [guidelines](guidelines.md).
 - For information about how to write documentation for the software, please have a look at the [documentation section](documentation.md)
+- For configuring PyCharm (code analysis + in-container test execution/debugging) please have a look at the [PyCharm setup guide](pycharm-setup.md)

--- a/docs/development/pycharm-setup.md
+++ b/docs/development/pycharm-setup.md
@@ -35,7 +35,8 @@ Start the containers with bind-mounted source so that breakpoints in your local 
 make docker_dev
 ```
 
-The `docker_dev` target starts all services with `docker/compose.dev.yaml` layered on top of the base compose file. The pipeline containers bind-mount the host source directories, so edits are immediately visible inside the containers.
+The `docker_dev` target starts all services with `docker/compose.dev.yaml` layered on top of the base compose file. The pipeline containers bind-mount the host source directories, so edits are
+immediately visible inside the containers.
 
 To start only the core service (faster for most development):
 
@@ -54,9 +55,9 @@ BAG3D_DOCKER_IMAGE_TAG=develop docker compose -p bag3d-dev \
 4. Set **Python interpreter path**: `/opt/3dbag-pipeline/venv/bin/python`
 5. Under **Path mappings**, add:
 
-    | Local path | Remote path |
-    |---|---|
-    | `<project-root>/packages` | `/opt/3dbag-pipeline/packages` |
+| Local path                | Remote path                    |
+|---------------------------|--------------------------------|
+| `<project-root>/packages` | `/opt/3dbag-pipeline/packages` |
 
 6. Click **OK** and wait for PyCharm to index the remote interpreter.
 
@@ -71,9 +72,11 @@ Once the Docker Compose interpreter is configured and the containers are running
 
 ## After editing Python files
 
-With bind-mounted source (`make docker_dev`), file changes are visible in the container immediately. However, Dagster's gRPC code server does not auto-detect file changes. After editing code, click **Reload** in the Dagster UI at [http://localhost:3000](http://localhost:3000) to reload the code location.
+With bind-mounted source (`make docker_dev`), file changes are visible in the container immediately. However, Dagster's gRPC code server does not auto-detect file changes. After editing code, click *
+*Reload** in the Dagster UI at [http://localhost:3000](http://localhost:3000) to reload the code location.
 
-If you prefer automatic reloads on save, use `make docker_watch` instead (Stage 1 sync+restart workflow). That triggers a container restart whenever source files change, at the cost of a few seconds of downtime per reload.
+If you prefer automatic reloads on save, use `make docker_watch` instead (Stage 1 sync+restart workflow). That triggers a container restart whenever source files change, at the cost of a few seconds
+of downtime per reload.
 
 ---
 

--- a/docs/development/pycharm-setup.md
+++ b/docs/development/pycharm-setup.md
@@ -1,0 +1,99 @@
+# PyCharm Setup
+
+PyCharm has two distinct needs when working with this project:
+
+- **Code analysis** (autocompletion, type checking, go-to-definition): needs a Python interpreter with all packages installed
+- **Test execution / debugging**: needs the Docker environment (database, tools, environment variables)
+
+The recommended approach is to configure a local venv for code analysis and a Docker Compose interpreter for running and debugging tests.
+
+---
+
+## Code analysis: local venv
+
+1. Run `make local_venv` to create per-package virtual environments.
+2. In PyCharm, go to **Settings → Project → Python Interpreter → Add Interpreter → Add Local Interpreter**.
+3. Select **Existing** and point it to the venv for the package you're working on:
+    - For `core` / `common`: `packages/core/.venv/bin/python`
+    - For `floors_estimation`: `packages/floors_estimation/.venv/bin/python`
+    - For `party_walls`: `packages/party_walls/.venv/bin/python`
+4. Mark source roots so PyCharm resolves cross-package imports correctly:
+    - Right-click `packages/core/src` → **Mark Directory as → Sources Root**
+    - Right-click `packages/common/src` → **Mark Directory as → Sources Root**
+
+This gives full autocompletion and type checking. External tool binaries (roofer, tyler, etc.) are not needed for code analysis.
+
+---
+
+## Test execution and debugging: Docker Compose interpreter
+
+### Prerequisites
+
+Start the containers with bind-mounted source so that breakpoints in your local files map directly to the running code:
+
+```bash
+make docker_dev
+```
+
+The `docker_dev` target starts all services with `docker/compose.dev.yaml` layered on top of the base compose file. The pipeline containers bind-mount the host source directories, so edits are immediately visible inside the containers.
+
+To start only the core service (faster for most development):
+
+```bash
+BAG3D_DOCKER_IMAGE_TAG=develop docker compose -p bag3d-dev \
+    -f docker/compose.yaml -f docker/compose.dev.yaml up -d
+```
+
+### Configure the Docker Compose interpreter in PyCharm
+
+1. Go to **Settings → Project → Python Interpreter → Add Interpreter → On Docker Compose**.
+2. Set **Configuration files**:
+    - `docker/compose.yaml`
+    - `docker/compose.dev.yaml` (add with the `+` button)
+3. Set **Service**: `bag3d-core` (or the package you're testing).
+4. Set **Python interpreter path**: `/opt/3dbag-pipeline/venv/bin/python`
+5. Under **Path mappings**, add:
+
+    | Local path | Remote path |
+    |---|---|
+    | `<project-root>/packages` | `/opt/3dbag-pipeline/packages` |
+
+6. Click **OK** and wait for PyCharm to index the remote interpreter.
+
+### Running tests with debugging
+
+Once the Docker Compose interpreter is configured and the containers are running with bind-mounted source (`make docker_dev`):
+
+- Right-click any test file or function and choose **Debug** — breakpoints in your local source files will be hit inside the container.
+- The test environment (PostgreSQL, environment variables from `docker/.env`) is available automatically because the test runs inside the container.
+
+---
+
+## After editing Python files
+
+With bind-mounted source (`make docker_dev`), file changes are visible in the container immediately. However, Dagster's gRPC code server does not auto-detect file changes. After editing code, click **Reload** in the Dagster UI at [http://localhost:3000](http://localhost:3000) to reload the code location.
+
+If you prefer automatic reloads on save, use `make docker_watch` instead (Stage 1 sync+restart workflow). That triggers a container restart whenever source files change, at the cost of a few seconds of downtime per reload.
+
+---
+
+## Selective service startup (profiles)
+
+The dev overlay defines compose profiles so you can start only the services you need:
+
+```bash
+# Start only core + databases + dagster (default, no profile flag needed)
+make docker_dev
+
+# Also start floors-estimation
+BAG3D_DOCKER_IMAGE_TAG=develop docker compose -p bag3d-dev \
+    -f docker/compose.yaml -f docker/compose.dev.yaml --profile floors up -d
+
+# Also start party-walls
+BAG3D_DOCKER_IMAGE_TAG=develop docker compose -p bag3d-dev \
+    -f docker/compose.yaml -f docker/compose.dev.yaml --profile party-walls up -d
+
+# Start everything
+BAG3D_DOCKER_IMAGE_TAG=develop docker compose -p bag3d-dev \
+    -f docker/compose.yaml -f docker/compose.dev.yaml --profile all up -d
+```

--- a/makefile
+++ b/makefile
@@ -52,6 +52,10 @@ docker_up:
 docker_up_nobuild:
 	BAG3D_DOCKER_IMAGE_TAG=$(BAG3D_DOCKER_IMAGE_TAG) docker compose -p $(COMPOSE_PROJECT_NAME) -f docker/compose.yaml up -d --no-build
 
+docker_dev:
+	BAG3D_DOCKER_IMAGE_TAG=$(BAG3D_DOCKER_IMAGE_TAG) docker compose -p $(COMPOSE_PROJECT_NAME) \
+		-f docker/compose.yaml -f docker/compose.dev.yaml up -d
+
 docker_watch:
 	BAG3D_DOCKER_IMAGE_TAG=$(BAG3D_DOCKER_IMAGE_TAG) docker compose -p $(COMPOSE_PROJECT_NAME) -f docker/compose.yaml watch
 

--- a/makefile
+++ b/makefile
@@ -70,6 +70,9 @@ docker_down:
 docker_down_rm:
 	docker compose -p $(COMPOSE_PROJECT_NAME) down --volumes --remove-orphans --rmi local
 
+docker_prune_cache:
+	docker builder prune --filter type=exec.cachemount
+
 test:
 	@set -e; set -o pipefail; \
 	rm -f tests/test.log; \

--- a/makefile
+++ b/makefile
@@ -53,8 +53,7 @@ docker_up_nobuild:
 	BAG3D_DOCKER_IMAGE_TAG=$(BAG3D_DOCKER_IMAGE_TAG) docker compose -p $(COMPOSE_PROJECT_NAME) -f docker/compose.yaml up -d --no-build
 
 docker_dev:
-	BAG3D_DOCKER_IMAGE_TAG=$(BAG3D_DOCKER_IMAGE_TAG) docker compose -p $(COMPOSE_PROJECT_NAME) \
-		-f docker/compose.yaml -f docker/compose.dev.yaml up -d
+	BAG3D_DOCKER_IMAGE_TAG=$(BAG3D_DOCKER_IMAGE_TAG) docker compose -p $(COMPOSE_PROJECT_NAME) -f docker/compose.yaml -f docker/compose.dev.yaml up -d
 
 docker_watch:
 	BAG3D_DOCKER_IMAGE_TAG=$(BAG3D_DOCKER_IMAGE_TAG) docker compose -p $(COMPOSE_PROJECT_NAME) -f docker/compose.yaml watch


### PR DESCRIPTION
- Speed up docker builds.
- Add `make docker_dev` that bind mounts source and test dirs so local development does not require image rebuilds or container restarts. But it does require dagster code location reloads manually.
- Bunch of claude plans.

Fixes #206 