### PR TITLE
Add fixture-backed integration data pipeline

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -33,6 +33,8 @@ BAG3D_CONCURRENCY_TOOL_VALIDATION=4
 # 3dbag-pipeline resource configuration
 DAGSTER_DEPLOYMENT="pytest"
 BAG3D_FILESTORE="/data/volume"
+BAG3D_INPUT_MODE="normal"
+BAG3D_INTEGRATION_DATA_DIR="/data/volume/integration-data"
 BAG3D_FILESTORE_FASTSSD="/data/volume"
 BAG3D_RELEASE_VERSION="test_version"
 BAG3D_FLOORS_ESTIMATION_MODEL="/data/volume/model/pipeline_model1_gbr_untuned.joblib"

--- a/docker/compose.integration-data.yaml
+++ b/docker/compose.integration-data.yaml
@@ -23,3 +23,8 @@ services:
     environment:
       BAG3D_INPUT_MODE: integration_data
       BAG3D_INTEGRATION_DATA_DIR: /data/volume/integration-data
+    volumes:
+      - type: bind
+        source: ${BAG3D_INTEGRATION_DATA_HOST_DIR}
+        target: /data/volume/integration-data
+        read_only: true

--- a/docker/compose.integration-data.yaml
+++ b/docker/compose.integration-data.yaml
@@ -1,0 +1,25 @@
+# Opt-in fixture-backed deployment preset. Use with compose.yaml and set
+# BAG3D_INTEGRATION_DATA_HOST_DIR to the canonical host snapshot directory.
+services:
+  bag3d-core:
+    environment:
+      BAG3D_INPUT_MODE: integration_data
+      BAG3D_INTEGRATION_DATA_DIR: /data/volume/integration-data
+    volumes:
+      - type: bind
+        source: ${BAG3D_INTEGRATION_DATA_HOST_DIR}
+        target: /data/volume/integration-data
+        read_only: true
+  dagster-daemon:
+    environment:
+      BAG3D_INPUT_MODE: integration_data
+      BAG3D_INTEGRATION_DATA_DIR: /data/volume/integration-data
+    volumes:
+      - type: bind
+        source: ${BAG3D_INTEGRATION_DATA_HOST_DIR}
+        target: /data/volume/integration-data
+        read_only: true
+  dagster-webserver:
+    environment:
+      BAG3D_INPUT_MODE: integration_data
+      BAG3D_INTEGRATION_DATA_DIR: /data/volume/integration-data

--- a/docs/plans/integration-data-runner.md
+++ b/docs/plans/integration-data-runner.md
@@ -1,0 +1,67 @@
+# Plan: Run the canonical pipeline with integration data
+
+## Goal
+
+Allow the existing `3dbag-admin/deployment/3dbag-pipeline/runner.py` workflow to execute the canonical pipeline against the generated integration-data snapshot, with no changes to `runner.py` itself or only small deployment-wrapper changes.
+
+The snapshot is treated as an external, read-only fixture. The `integration_data` job remains responsible for refreshing the fixture; it is not part of the canonical end-to-end run.
+
+## Implementation
+
+### 1. Enable the existing fixture mode
+
+Use the existing fixture asset replacement in `packages/core/src/bag3d/core/asset_groups.py` and the adapters in `packages/core/src/bag3d/core/assets/fixture_adapters.py`.
+
+The user deployment must set the following variables in every process that loads or executes core definitions:
+
+```text
+BAG3D_INPUT_MODE=integration_data
+BAG3D_INTEGRATION_DATA_DIR=/data/volume/integration-data
+```
+
+Apply the existing `docker/compose.integration-data.yaml` overlay to both deployment startup and the `dagster-runner` Compose command. Pass the host snapshot through:
+
+```text
+BAG3D_INTEGRATION_DATA_HOST_DIR=/home/balazs/.config/JetBrains/PyCharm2026.2/docker/3dbag-pipeline-core-2026_07_29/data/volume/integration-data
+```
+
+The overlay must mount this directory read-only at `/data/volume/integration-data` in `bag3d-core`, `dagster-daemon`, and `dagster-webserver`.
+
+### 2. Override the runner’s development preset
+
+The current user preset targets a different AOI and AHN tile. Add an integration-specific environment file that is loaded after the normal `preset.env`:
+
+```text
+DATA_DEVELOP_AOI="POLYGON ((121967 485750, 123354 485750, 123354 486550, 121967 486550, 121967 485750))"
+DATA_DEVELOP_AHN_TILES="25gn1"
+```
+
+Do not set `DATA_DEVELOP_AHN6_TILES` for the current snapshot because its manifest contains no AHN6 partitions. The runner will consequently skip the AHN6 stage in testing mode.
+
+The environment file can be generated from `integration-data/manifest.json` so that future snapshots do not require hard-coded AOI or partition values.
+
+### 3. Update the user deployment wrapper
+
+Modify the user deployment files in `3dbag-admin/deployment/3dbag-pipeline/user/`:
+
+- include `compose.integration-data.yaml` in the `deploy` and `test` Compose file lists;
+- provide `BAG3D_INTEGRATION_DATA_HOST_DIR` as a configurable deployment variable;
+- mount and pass the generated integration environment file to `runner.py` after `preset.env`;
+- keep the existing `--mode testing` invocation and stage ordering.
+
+No `runner.py` changes are required. Its existing testing configuration still supplies geofilters and AHN job configuration, while the core code location selects the fixture-backed assets through `BAG3D_INPUT_MODE`.
+
+## Validation
+
+- Render the final Compose configuration and verify that all three required services receive the fixture variables and read-only mount.
+- Confirm the runner sees the snapshot AOI and `25gn1`, rather than the default user preset.
+- Run `source_input` and verify that BAG, BGT, TOP10NL, CBS, and AHN inputs come from the snapshot without downloading source data.
+- Run the complete fixture-backed pipeline through export.
+- Verify that default/production input mode remains unchanged when the overlay is omitted.
+- Add deployment-wrapper tests for overlay selection, environment-file ordering, and snapshot-path validation.
+
+## Assumptions
+
+- The snapshot is available on the deployment host at the supplied path and has a valid fixture-version-2 manifest.
+- The snapshot is not copied into Git or modified by pipeline runs.
+- The four existing Dagster code locations and the external runner remain unchanged for this plan.

--- a/docs/plans/native-dagster-orchestration.md
+++ b/docs/plans/native-dagster-orchestration.md
@@ -1,0 +1,94 @@
+# Plan: Native Dagster orchestration for the full pipeline
+
+## Goal
+
+Run the complete 3DBAG pipeline using Dagster schedules, sensors, partitions, and run coordination, without relying on `3dbag-admin/deployment/3dbag-pipeline/runner.py`.
+
+Preserve the existing `core`, `party_walls`, `floors_estimation`, and `export` code locations. A single Dagster job cannot directly span these locations, so the native implementation must coordinate jobs and asset materializations across the deployment.
+
+## Implementation
+
+### 1. Add a native pipeline kickoff
+
+Add a core-location schedule or manually launchable kickoff job that starts:
+
+- `source_input`;
+- `ahn_tile_index`.
+
+The kickoff must assign a shared pipeline-run identifier and a mode/input tag. In integration mode it must also identify the fixture manifest and selected partitions.
+
+Move the runner’s concurrency-pool setup into deployment configuration or a Dagster startup/bootstrap step. Pool limits must not depend on a GraphQL mutation performed by the external runner.
+
+### 2. Coordinate core stages with sensors
+
+Add core-location run-status sensors for the local sequence:
+
+1. after `ahn_tile_index` succeeds, launch the AHN 3/4/5 partitioned jobs for the selected partition set;
+2. after all required AHN partition runs succeed, launch `ahn_metadata_index`;
+3. after source input and AHN metadata are ready, register reconstruction partitions and launch `reconstruct`.
+
+Each sensor must use a persisted cursor and deterministic run keys. It must not launch a downstream stage after only one partition succeeds.
+
+### 3. Replace import-time reconstruction partitions
+
+The current reconstruction partition definition queries the database during code-location import. This currently requires the runner to reload the code location after input preparation.
+
+Replace this with a stable Dagster dynamic-partition definition:
+
+- declare the dynamic partition definition at import time;
+- after `input.tiles` is materialized, query the resulting tile IDs;
+- add those IDs to the dynamic partition set;
+- launch reconstruction runs for those keys;
+- remove the dependency on code-location reloads for normal orchestration.
+
+Fixture mode must derive its AHN and reconstruction partition selections from the snapshot manifest instead of from the user deployment’s hard-coded preset.
+
+### 4. Add cross-location stage sensors
+
+Add deployment-wide sensors in the downstream locations:
+
+- `party_walls` sensor: monitor successful completion of the core reconstruction stage, then request `party_walls`;
+- `floors_estimation` sensor: monitor successful `party_walls`, then request `floors_estimation`;
+- `export` sensor: monitor successful `floors_estimation`, then request `export`.
+
+Use native Dagster asset/run sensors with `monitor_all_code_locations` where appropriate. Each stage request must carry the shared pipeline-run identifier, release version, input mode, and stage name.
+
+The completion barrier for partitioned stages must track the expected partition set and terminal status. A barrier must be satisfied only when every required partition succeeds; failures must stop downstream execution and remain visible in Dagster run history.
+
+### 5. Move remaining runner responsibilities into Dagster
+
+- Make reconstruction and export output preparation idempotent, or add dedicated native preparation assets/jobs for stage cleanup.
+- Configure retry and partial-failure behavior on the Dagster jobs/sensors rather than in runner polling code.
+- Use Dagster run status sensors and configured alerting for failure summaries and notifications.
+- Use Dagster run monitoring, tags, event logs, and the UI instead of runner-side polling and hardware summaries.
+- Keep the existing asset dependencies as the source of truth for data handoffs; do not introduce duplicate sequencing metadata in the deployment manifest unless required for partition-barrier state.
+
+## Interfaces and state
+
+Use the following run-tag contract:
+
+```text
+3dbag/pipeline-run   <unique pipeline execution id>
+3dbag/stage          <stage name>
+3dbag/input-mode     <production|testing|integration_data>
+3dbag/expected-keys  <serialized expected partition keys, where applicable>
+```
+
+Sensor cursors must record the stage-run identifier, expected partitions, observed successes/failures, and whether the downstream request has already been emitted. Re-evaluating a sensor after a daemon restart must be safe.
+
+## Validation
+
+- Validate every code location with `dg check defs`.
+- Test dynamic reconstruction partition registration from a materialized `input.tiles` asset.
+- Test AHN, reconstruction, and export completion barriers with zero, partial, successful, and failed partition sets.
+- Test cross-location sensors and duplicate-run prevention after sensor restarts.
+- Run the complete integration-data pipeline without `runner.py`, from kickoff through export.
+- Verify that production mode still selects the full source datasets and that fixture mode performs no source downloads.
+- Confirm concurrency limits, retries, cleanup, and failure notifications work when the runner container is absent.
+
+## Assumptions
+
+- The existing four code locations remain separate.
+- Native Dagster sensors are acceptable as the cross-location orchestration mechanism.
+- The integration-data snapshot remains a read-only external fixture.
+- Existing asset keys and file/database stage handoffs remain compatible; changes are limited to partition registration, orchestration, execution state, and deployment configuration.

--- a/packages/common/src/bag3d/common/resources/__init__.py
+++ b/packages/common/src/bag3d/common/resources/__init__.py
@@ -85,6 +85,7 @@ def resources_by_deployment(dagster_deployment: str) -> dict:
             "gdal": GDALResource.configure_at_launch(),
             "file_store": FileStoreResource.configure_at_launch(),
             "pointcloud_store": FileStoreResource.configure_at_launch(),
+            "integration_data_store": FileStoreResource.configure_at_launch(),
             "computation_db": DatabaseResource.configure_at_launch(),
             "pdal": PDALResource.configure_at_launch(),
             "lastools": LASToolsResource.configure_at_launch(),
@@ -112,6 +113,12 @@ def resources_by_deployment(dagster_deployment: str) -> dict:
                     "BAG3D_POINTCLOUD_DIR",
                     str(Path(os.environ["BAG3D_FILESTORE"]) / "pointcloud"),
                 ),
+            ),
+            "integration_data_store": FileStoreResource(
+                root_dir=os.getenv(
+                    "BAG3D_INTEGRATION_DATA_DIR",
+                    str(Path(os.environ["BAG3D_FILESTORE"]) / "integration-data"),
+                )
             ),
             "computation_db": DatabaseResource(
                 host=os.environ["BAG3D_PG_HOST"],

--- a/packages/common/src/bag3d/common/testing/mock_resources.py
+++ b/packages/common/src/bag3d/common/testing/mock_resources.py
@@ -3,6 +3,7 @@ import dagster as dg
 MOCK_RESOURCES = {
     "file_store": dg.ResourceDefinition.mock_resource(),
     "pointcloud_store": dg.ResourceDefinition.mock_resource(),
+    "integration_data_store": dg.ResourceDefinition.mock_resource(),
     "gdal": dg.ResourceDefinition.mock_resource(),
     "computation_db": dg.ResourceDefinition.mock_resource(),
     "publication_db": dg.ResourceDefinition.mock_resource(),

--- a/packages/core/src/bag3d/core/asset_groups.py
+++ b/packages/core/src/bag3d/core/asset_groups.py
@@ -1,4 +1,5 @@
 from dagster import load_assets_from_package_module, load_assets_from_modules
+from os import getenv
 
 from bag3d.core.assets import (
     ahn,
@@ -51,10 +52,17 @@ reconstruction_assets = load_assets_from_package_module(
 )
 
 from bag3d.core.assets import integration_data  # noqa: E402
+from bag3d.core.assets.fixture_adapters import fixture_assets  # noqa: E402
 
 integration_data_assets = load_assets_from_modules(
     [integration_data], group_name="integration_data"
 )
+
+if getenv("BAG3D_INPUT_MODE", "").lower() == "integration_data":
+    fixture_keys = {asset.key for asset in fixture_assets}
+    bgt_assets = [asset for asset in bgt_assets if asset.key not in fixture_keys]
+    source_assets = [asset for asset in source_assets if asset.key not in fixture_keys]
+    source_assets.extend(fixture_assets)
 
 all_assets = [
     *bgt_assets,

--- a/packages/core/src/bag3d/core/asset_groups.py
+++ b/packages/core/src/bag3d/core/asset_groups.py
@@ -1,4 +1,4 @@
-from dagster import load_assets_from_package_module
+from dagster import load_assets_from_package_module, load_assets_from_modules
 
 from bag3d.core.assets import (
     ahn,
@@ -50,9 +50,16 @@ reconstruction_assets = load_assets_from_package_module(
     group_name=RECONSTRUCTION,
 )
 
+from bag3d.core.assets import integration_data  # noqa: E402
+
+integration_data_assets = load_assets_from_modules(
+    [integration_data], group_name="integration_data"
+)
+
 all_assets = [
     *bgt_assets,
     *source_assets,
     *input_assets,
     *reconstruction_assets,
+    *integration_data_assets,
 ]

--- a/packages/core/src/bag3d/core/assets/bag/download.py
+++ b/packages/core/src/bag3d/core/assets/bag/download.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from logging import Logger
 from typing import Tuple, Optional
 from copy import deepcopy
+import zipfile
 
 from dagster import (
     asset,
@@ -13,6 +14,7 @@ from dagster import (
 )
 from pydantic import Field
 from lxml import objectify  # type: ignore[attr-defined]
+from psycopg.sql import SQL, Identifier
 
 from bag3d.common.resources.files import FileStoreResource
 from bag3d.common.resources.database import DatabaseResource
@@ -28,6 +30,48 @@ from bag3d.common.utils.database import (
 from bag3d.common.types import PostgresTableIdentifier, Path
 
 logger = get_dagster_logger("bag.download")
+
+
+_EMPTY_BAG_COLUMNS = {
+    "pand": (
+        ("ogc_fid", "BIGINT"), ("oorspronkelijkbouwjaar", "INTEGER"),
+        ("identificatie", "TEXT"), ("status", "TEXT"), ("geconstateerd", "TEXT"),
+        ("documentdatum", "DATE"), ("documentnummer", "TEXT"),
+        ("voorkomenidentificatie", "TEXT"), ("begingeldigheid", "TIMESTAMPTZ"),
+        ("eindgeldigheid", "TIMESTAMPTZ"), ("tijdstipregistratie", "TIMESTAMPTZ"),
+        ("eindregistratie", "TIMESTAMPTZ"), ("tijdstipinactief", "TIMESTAMPTZ"),
+        ("tijdstipregistratielv", "TIMESTAMPTZ"),
+        ("tijdstipeindregistratielv", "TIMESTAMPTZ"),
+        ("tijdstipinactieflv", "TIMESTAMPTZ"),
+        ("tijdstipnietbaglv", "TIMESTAMPTZ"),
+        ("wkb_geometry", "geometry(Polygon, 28992)"),
+    ),
+    "verblijfsobject": (
+        ("ogc_fid", "BIGINT"), ("gebruiksdoel", "TEXT[]"), ("oppervlakte", "INTEGER"),
+        ("hoofdadresnummeraanduidingref", "TEXT[]"),
+        ("nevenadresnummeraanduidingref", "TEXT[]"), ("pandref", "TEXT[]"),
+        ("identificatie", "TEXT"), ("status", "TEXT"), ("geconstateerd", "TEXT"),
+        ("documentdatum", "DATE"), ("documentnummer", "TEXT"),
+        ("voorkomenidentificatie", "TEXT"), ("begingeldigheid", "TIMESTAMPTZ"),
+        ("eindgeldigheid", "TIMESTAMPTZ"), ("tijdstipregistratie", "TIMESTAMPTZ"),
+        ("eindregistratie", "TIMESTAMPTZ"), ("tijdstipinactief", "TIMESTAMPTZ"),
+        ("tijdstipregistratielv", "TIMESTAMPTZ"),
+        ("tijdstipeindregistratielv", "TIMESTAMPTZ"),
+        ("tijdstipinactieflv", "TIMESTAMPTZ"),
+        ("tijdstipnietbaglv", "TIMESTAMPTZ"),
+        ("wkb_geometry", "geometry(Polygon, 28992)"),
+    ),
+}
+
+
+def _create_empty_bag_layer(computation_db, table, layer):
+    definition = SQL(", ").join(
+        Identifier(name) + SQL(f" {sql_type}")
+        for name, sql_type in _EMPTY_BAG_COLUMNS[layer]
+    )
+    computation_db.connection.send_query(
+        SQL("CREATE TABLE {} ({})").format(table.id, definition)
+    )
 
 
 class BagDownloadConfig(Config):
@@ -300,6 +344,13 @@ def load_bag_layer(
         "woonplaats": "wpl",
     }
     layer_id = layername_map[layer.lower()].upper()
+    layer_zip = Path(f"{extract_dir}/9999{layer_id}{shortdate}.zip")
+    if layer_zip.is_file() and zipfile.is_zipfile(layer_zip):
+        with zipfile.ZipFile(layer_zip) as archive:
+            if not archive.namelist():
+                logger.info("BAG layer archive is empty; creating an empty table")
+                _create_empty_bag_layer(computation_db, new_table, layer.lower())
+                return True
     kwargs = {
         "layer_dir": layer_id,
         "shortdate": shortdate,

--- a/packages/core/src/bag3d/core/assets/cbs/load.py
+++ b/packages/core/src/bag3d/core/assets/cbs/load.py
@@ -39,6 +39,12 @@ def _load_records_to_postgres(
     per column. Data is inserted via psycopg executemany.
     """
     if not records:
+        conn = computation_db.connection
+        conn.send_query(
+            SQL("CREATE TABLE {} ({})").format(
+                table.id, Identifier("ID") + SQL(" TEXT")
+            )
+        )
         return
 
     conn = computation_db.connection

--- a/packages/core/src/bag3d/core/assets/fixture_adapters.py
+++ b/packages/core/src/bag3d/core/assets/fixture_adapters.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
@@ -14,7 +15,7 @@ from bag3d.core.assets.ahn.core import (
 )
 from bag3d.core.assets.ahn.download import BatchLAZDownload, LAZDownload
 
-FIXTURE_VERSION = "1"
+FIXTURE_VERSION = "2"
 
 
 @dataclass(frozen=True)
@@ -37,10 +38,6 @@ class FixtureManifest:
 
 def _verify(root: Path, manifest: Mapping[str, Any], relative: str) -> None:
     files = manifest.get("files")
-    if not isinstance(files, Mapping) or relative not in files:
-        raise ValueError(
-            f"Fixture manifest does not declare required file {relative!r}"
-        )
     path = (root / relative).resolve()
     if path.is_dir():
         for child in path.rglob("*"):
@@ -49,7 +46,7 @@ def _verify(root: Path, manifest: Mapping[str, Any], relative: str) -> None:
                     f"Fixture manifest does not declare required file {child.relative_to(root)!s}"
                 )
         return
-    if relative not in files:
+    if not isinstance(files, Mapping) or relative not in files:
         raise ValueError(
             f"Fixture manifest does not declare required file {relative!r}"
         )
@@ -86,6 +83,13 @@ def validate_fixture_manifest(root: Path) -> FixtureManifest:
         raise ValueError(
             f"Unsupported integration-data fixture version {manifest.get('fixture_version')!r}; expected {FIXTURE_VERSION!r}"
         )
+    aoi = manifest.get("aoi")
+    expected_aoi = {"wkt", "minx", "miny", "maxx", "maxy"}
+    if not isinstance(aoi, Mapping) or not expected_aoi.issubset(aoi):
+        raise ValueError("Integration-data manifest is missing AOI metadata")
+    clipping = manifest.get("clipping")
+    if not isinstance(clipping, Mapping) or clipping.get("vectors") != "gdal" or clipping.get("pointclouds") != "las2las_keep_xy":
+        raise ValueError("Integration-data manifest has unsupported clipping metadata")
     sources = manifest.get("sources")
     required = {"bag", "bgt", "top10nl", "cbs_key_figures", "cbs_buurtkaart"}
     if not isinstance(sources, Mapping):
@@ -124,6 +128,14 @@ def validate_fixture_manifest(root: Path) -> FixtureManifest:
             if not isinstance(entry, Mapping) or not isinstance(entry.get("path"), str):
                 raise ValueError(f"Invalid AHN{version} partition entry")
             _verify(root, manifest, entry["path"])
+    files = manifest.get("files")
+    if not isinstance(files, Mapping):
+        raise ValueError("Integration-data manifest is missing files")
+    actual = {str(path.relative_to(root)) for path in root.rglob("*") if path.is_file() and path.name != "manifest.json"}
+    if actual != set(files):
+        raise ValueError("Integration-data manifest file list does not match snapshot")
+    for relative in actual:
+        _verify(root, manifest, relative)
     for name, source in sources.items():
         if not isinstance(source, Mapping) or not isinstance(source.get("path"), str):
             raise ValueError(
@@ -221,7 +233,7 @@ def fixture_sha256_ahn6(integration_data_store: FileStoreResource):
     return _checks(integration_data_store, 6)
 
 
-def _laz(store, version, tile):
+def _laz(store, version, tile, pointcloud_store):
     m = _m(store)
     entries = m.value["ahn"]["partitions"].get(str(version), {})
     entry = entries.get(tile)
@@ -236,23 +248,25 @@ def _laz(store, version, tile):
         )
     if not isinstance(entry, Mapping) or not isinstance(entry.get("path"), str):
         raise ValueError(f"Fixture AHN{version} partition is missing tile {tile}")
-    path = m.path(entry["path"])
-    return LAZDownload(
-        str(entry.get("url", path.name)),
-        path,
-        True,
-        entry.get("hash_name"),
-        entry.get("hash_hexdigest"),
-        False,
-        path.stat().st_size / 1e6,
-    )
+    source = m.path(entry["path"])
+    destination = Path(pointcloud_store.root_dir) / "integration-fixture" / f"AHN{version}" / source.name
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if not destination.is_file() or destination.stat().st_size != source.stat().st_size:
+        shutil.copy2(source, destination)
+    digest = hashlib.sha256(destination.read_bytes()).hexdigest()
+    expected = entry.get("sha256")
+    if expected and digest != expected:
+        raise ValueError(f"Fixture AHN{version} checksum does not match manifest: {source}")
+    return LAZDownload(str(entry.get("url", source.name)), destination, True, "sha256", digest, False, destination.stat().st_size / 1e6)
 
 
 def _adapter(version):
     def adapter(
-        context: AssetExecutionContext, integration_data_store: FileStoreResource
+        context: AssetExecutionContext,
+        integration_data_store: FileStoreResource,
+        pointcloud_store: FileStoreResource,
     ):
-        value = _laz(integration_data_store, version, context.partition_key)
+        value = _laz(integration_data_store, version, context.partition_key, pointcloud_store)
         return Output(value, metadata=value.asdict())
 
     return adapter
@@ -285,12 +299,14 @@ fixture_laz_files_ahn5 = asset(
     partitions_def=partition_definition_ahn6_batches,
 )
 def fixture_laz_files_ahn6(
-    context: AssetExecutionContext, integration_data_store: FileStoreResource
+    context: AssetExecutionContext,
+    integration_data_store: FileStoreResource,
+    pointcloud_store: FileStoreResource,
 ):
     m = _m(integration_data_store)
     entries = m.value["ahn"]["partitions"].get("6", {}).get(context.partition_key, {})
     tiles = {
-        tile: _laz(integration_data_store, 6, tile)
+        tile: _laz(integration_data_store, 6, tile, pointcloud_store)
         for tile in tiles_in_batch(context.partition_key)
         if tile in entries
     }

--- a/packages/core/src/bag3d/core/assets/fixture_adapters.py
+++ b/packages/core/src/bag3d/core/assets/fixture_adapters.py
@@ -1,0 +1,319 @@
+"""Read-only adapters for the local integration-data snapshot."""
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+from dagster import AssetExecutionContext, Output, asset
+from bag3d.common.resources.files import FileStoreResource
+from bag3d.core.assets.ahn.core import (
+    partition_definition_ahn,
+    partition_definition_ahn6_batches,
+    tiles_in_batch,
+)
+from bag3d.core.assets.ahn.download import BatchLAZDownload, LAZDownload
+
+FIXTURE_VERSION = "1"
+
+
+@dataclass(frozen=True)
+class FixtureManifest:
+    root: Path
+    value: Mapping[str, Any]
+
+    def path(self, relative: str) -> Path:
+        path = (self.root / relative).resolve()
+        try:
+            path.relative_to(self.root.resolve())
+        except ValueError as exc:
+            raise ValueError(
+                f"Fixture path escapes snapshot root: {relative!r}"
+            ) from exc
+        if not path.exists():
+            raise FileNotFoundError(f"Fixture path is missing: {relative}")
+        return path
+
+
+def _verify(root: Path, manifest: Mapping[str, Any], relative: str) -> None:
+    files = manifest.get("files")
+    if not isinstance(files, Mapping) or relative not in files:
+        raise ValueError(
+            f"Fixture manifest does not declare required file {relative!r}"
+        )
+    path = (root / relative).resolve()
+    if path.is_dir():
+        for child in path.rglob("*"):
+            if child.is_file() and str(child.relative_to(root)) not in files:
+                raise ValueError(
+                    f"Fixture manifest does not declare required file {child.relative_to(root)!s}"
+                )
+        return
+    if relative not in files:
+        raise ValueError(
+            f"Fixture manifest does not declare required file {relative!r}"
+        )
+    if not path.is_file():
+        raise FileNotFoundError(f"Fixture file is missing: {relative}")
+    entry = (
+        files[relative]
+        if isinstance(files[relative], Mapping)
+        else {"size": files[relative]}
+    )
+    if entry.get("size") is not None and path.stat().st_size != int(entry["size"]):
+        raise ValueError(f"Fixture file size does not match manifest: {relative}")
+    if (
+        entry.get("sha256")
+        and hashlib.sha256(path.read_bytes()).hexdigest() != entry["sha256"]
+    ):
+        raise ValueError(f"Fixture checksum does not match manifest: {relative}")
+
+
+def validate_fixture_manifest(root: Path) -> FixtureManifest:
+    root = root.resolve()
+    path = root / "manifest.json"
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Integration-data snapshot is incomplete: {path} is missing"
+        )
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid integration-data manifest: {path}") from exc
+    if not isinstance(manifest, Mapping):
+        raise ValueError("Integration-data manifest must contain a JSON object")
+    if str(manifest.get("fixture_version")) != FIXTURE_VERSION:
+        raise ValueError(
+            f"Unsupported integration-data fixture version {manifest.get('fixture_version')!r}; expected {FIXTURE_VERSION!r}"
+        )
+    sources = manifest.get("sources")
+    required = {"bag", "bgt", "top10nl", "cbs_key_figures", "cbs_buurtkaart"}
+    if not isinstance(sources, Mapping):
+        raise ValueError("Integration-data manifest is missing sources")
+    if missing := required - set(sources):
+        raise ValueError(
+            f"Integration-data manifest is missing sources: {sorted(missing)}"
+        )
+    ahn = manifest.get("ahn")
+    if (
+        not isinstance(ahn, Mapping)
+        or not isinstance(ahn.get("indexes"), Mapping)
+        or not isinstance(ahn.get("checksums"), Mapping)
+        or not isinstance(ahn.get("partitions"), Mapping)
+    ):
+        raise ValueError(
+            "Integration-data manifest is missing AHN indexes, checksums, or partitions"
+        )
+    if not {"3", "6"}.issubset(ahn["indexes"]):
+        raise ValueError("Integration-data manifest must contain AHN3 and AHN6 indexes")
+    if not {"3", "4", "5", "6"}.issubset(ahn["checksums"]):
+        raise ValueError("Integration-data manifest must contain AHN3-AHN6 checksums")
+    for version, partitions in ahn["partitions"].items():
+        if not isinstance(partitions, Mapping):
+            raise ValueError(f"Invalid AHN{version} partition mapping")
+        values = (
+            entry
+            for batch in partitions.values()
+            for entry in (
+                batch.values()
+                if version == "6" and isinstance(batch, Mapping)
+                else [batch]
+            )
+        )
+        for entry in values:
+            if not isinstance(entry, Mapping) or not isinstance(entry.get("path"), str):
+                raise ValueError(f"Invalid AHN{version} partition entry")
+            _verify(root, manifest, entry["path"])
+    for name, source in sources.items():
+        if not isinstance(source, Mapping) or not isinstance(source.get("path"), str):
+            raise ValueError(
+                f"Invalid source entry in integration-data manifest: {name}"
+            )
+        _verify(root, manifest, source["path"])
+    return FixtureManifest(root, manifest)
+
+
+def _m(store):
+    return validate_fixture_manifest(Path(store.root_dir))
+
+
+def _src(m, name):
+    return m.value["sources"][name]
+
+
+def _path(m, name):
+    return m.path(_src(m, name)["path"])
+
+
+@asset(name="extract_bag", key_prefix="bag", group_name="bag")
+def fixture_extract_bag(integration_data_store: FileStoreResource):
+    m = _m(integration_data_store)
+    s = _src(m, "bag")
+    return Output((_path(m, "bag"), dict(s["metadata"]), str(s["shortdate"])))
+
+
+@asset(name="extract_bgt", key_prefix="bgt", group_name="bgt")
+def fixture_extract_bgt(integration_data_store: FileStoreResource):
+    return _path(_m(integration_data_store), "bgt")
+
+
+@asset(name="extract_top10nl", key_prefix="top10nl", group_name="top10nl")
+def fixture_extract_top10nl(integration_data_store: FileStoreResource):
+    return _path(_m(integration_data_store), "top10nl")
+
+
+@asset(name="extract_cbs_key_figures", key_prefix="cbs", group_name="cbs")
+def fixture_extract_cbs_key_figures(integration_data_store: FileStoreResource):
+    value = json.loads(
+        _path(_m(integration_data_store), "cbs_key_figures").read_text(encoding="utf-8")
+    )
+    if not isinstance(value, list):
+        raise ValueError("Fixture CBS key figures must be a JSON list")
+    return value
+
+
+@asset(name="extract_cbs_buurtkaart", key_prefix="cbs", group_name="cbs")
+def fixture_extract_cbs_buurtkaart(integration_data_store: FileStoreResource):
+    return _path(_m(integration_data_store), "cbs_buurtkaart")
+
+
+def _ahn(store, version):
+    value = _m(store).value["ahn"]["indexes"].get(str(version))
+    if not isinstance(value, Mapping):
+        raise ValueError(f"Fixture AHN{version} index is missing")
+    return dict(value)
+
+
+@asset(name="tile_index_ahn", key_prefix="ahn", group_name="ahn")
+def fixture_tile_index_ahn(integration_data_store: FileStoreResource):
+    return _ahn(integration_data_store, 3)
+
+
+@asset(name="tile_index_ahn6", key_prefix="ahn", group_name="ahn")
+def fixture_tile_index_ahn6(integration_data_store: FileStoreResource):
+    return _ahn(integration_data_store, 6)
+
+
+def _checks(store, version):
+    value = _m(store).value["ahn"]["checksums"].get(str(version))
+    if not isinstance(value, Mapping):
+        raise ValueError(f"Fixture AHN{version} checksums are missing")
+    return {str(k): str(v) for k, v in value.items()}
+
+
+@asset(name="md5_ahn3", key_prefix="ahn", group_name="ahn")
+def fixture_md5_ahn3(integration_data_store: FileStoreResource):
+    return _checks(integration_data_store, 3)
+
+
+@asset(name="md5_ahn4", key_prefix="ahn", group_name="ahn")
+def fixture_md5_ahn4(integration_data_store: FileStoreResource):
+    return _checks(integration_data_store, 4)
+
+
+@asset(name="sha256_ahn5", key_prefix="ahn", group_name="ahn")
+def fixture_sha256_ahn5(integration_data_store: FileStoreResource):
+    return _checks(integration_data_store, 5)
+
+
+@asset(name="sha256_ahn6", key_prefix="ahn", group_name="ahn")
+def fixture_sha256_ahn6(integration_data_store: FileStoreResource):
+    return _checks(integration_data_store, 6)
+
+
+def _laz(store, version, tile):
+    m = _m(store)
+    entries = m.value["ahn"]["partitions"].get(str(version), {})
+    entry = entries.get(tile)
+    if version == 6 and entry is None:
+        entry = next(
+            (
+                batch.get(tile)
+                for batch in entries.values()
+                if isinstance(batch, Mapping) and tile in batch
+            ),
+            None,
+        )
+    if not isinstance(entry, Mapping) or not isinstance(entry.get("path"), str):
+        raise ValueError(f"Fixture AHN{version} partition is missing tile {tile}")
+    path = m.path(entry["path"])
+    return LAZDownload(
+        str(entry.get("url", path.name)),
+        path,
+        True,
+        entry.get("hash_name"),
+        entry.get("hash_hexdigest"),
+        False,
+        path.stat().st_size / 1e6,
+    )
+
+
+def _adapter(version):
+    def adapter(
+        context: AssetExecutionContext, integration_data_store: FileStoreResource
+    ):
+        value = _laz(integration_data_store, version, context.partition_key)
+        return Output(value, metadata=value.asdict())
+
+    return adapter
+
+
+fixture_laz_files_ahn3 = asset(
+    name="laz_files_ahn3",
+    key_prefix="ahn",
+    group_name="ahn",
+    partitions_def=partition_definition_ahn,
+)(_adapter(3))
+fixture_laz_files_ahn4 = asset(
+    name="laz_files_ahn4",
+    key_prefix="ahn",
+    group_name="ahn",
+    partitions_def=partition_definition_ahn,
+)(_adapter(4))
+fixture_laz_files_ahn5 = asset(
+    name="laz_files_ahn5",
+    key_prefix="ahn",
+    group_name="ahn",
+    partitions_def=partition_definition_ahn,
+)(_adapter(5))
+
+
+@asset(
+    name="laz_files_ahn6",
+    key_prefix="ahn",
+    group_name="ahn",
+    partitions_def=partition_definition_ahn6_batches,
+)
+def fixture_laz_files_ahn6(
+    context: AssetExecutionContext, integration_data_store: FileStoreResource
+):
+    m = _m(integration_data_store)
+    entries = m.value["ahn"]["partitions"].get("6", {}).get(context.partition_key, {})
+    tiles = {
+        tile: _laz(integration_data_store, 6, tile)
+        for tile in tiles_in_batch(context.partition_key)
+        if tile in entries
+    }
+    return Output(
+        BatchLAZDownload(context.partition_key, tiles),
+        metadata={"batch": context.partition_key, "tiles": len(tiles)},
+    )
+
+
+fixture_assets = [
+    fixture_extract_bag,
+    fixture_extract_bgt,
+    fixture_extract_top10nl,
+    fixture_extract_cbs_key_figures,
+    fixture_extract_cbs_buurtkaart,
+    fixture_tile_index_ahn,
+    fixture_tile_index_ahn6,
+    fixture_md5_ahn3,
+    fixture_md5_ahn4,
+    fixture_sha256_ahn5,
+    fixture_sha256_ahn6,
+    fixture_laz_files_ahn3,
+    fixture_laz_files_ahn4,
+    fixture_laz_files_ahn5,
+    fixture_laz_files_ahn6,
+]

--- a/packages/core/src/bag3d/core/assets/fixture_adapters.py
+++ b/packages/core/src/bag3d/core/assets/fixture_adapters.py
@@ -175,11 +175,27 @@ def _path(m, name):
     return m.path(_src(m, name)["path"])
 
 
+def _writable_fixture_copy(
+    file_store: FileStoreResource, source: Path, relative: str
+) -> Path:
+    destination = Path(file_store.root_dir) / "fixture-inputs" / relative
+    if source.is_dir():
+        shutil.rmtree(destination, ignore_errors=True)
+        shutil.copytree(source, destination)
+    else:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    return destination
+
+
 @asset(name="extract_bag", key_prefix="bag", group_name="bag")
-def fixture_extract_bag(integration_data_store: FileStoreResource):
+def fixture_extract_bag(
+    integration_data_store: FileStoreResource, file_store: FileStoreResource
+):
     m = _m(integration_data_store)
     s = _src(m, "bag")
-    return Output((_path(m, "bag"), dict(s["metadata"]), str(s["shortdate"])))
+    extract = _writable_fixture_copy(file_store, _path(m, "bag"), "bag")
+    return Output((extract, dict(s["metadata"]), str(s["shortdate"])))
 
 
 @asset(name="extract_bgt", key_prefix="bgt", group_name="bgt")

--- a/packages/core/src/bag3d/core/assets/fixture_adapters.py
+++ b/packages/core/src/bag3d/core/assets/fixture_adapters.py
@@ -90,6 +90,24 @@ def validate_fixture_manifest(root: Path) -> FixtureManifest:
     clipping = manifest.get("clipping")
     if not isinstance(clipping, Mapping) or clipping.get("vectors") != "gdal" or clipping.get("pointclouds") != "las2las_keep_xy":
         raise ValueError("Integration-data manifest has unsupported clipping metadata")
+    validation = manifest.get("validation")
+    if not isinstance(validation, Mapping) or validation.get("buffer_metres") != 10.0:
+        raise ValueError("Integration-data manifest is missing 10 m validation metadata")
+    extents = validation.get("extents")
+    if not isinstance(extents, Mapping) or not isinstance(extents.get("vectors"), Mapping) or not isinstance(extents.get("pointclouds"), Mapping):
+        raise ValueError("Integration-data manifest is missing computed extents")
+    bounds = (float(aoi["minx"]) - 10.0, float(aoi["miny"]) - 10.0, float(aoi["maxx"]) + 10.0, float(aoi["maxy"]) + 10.0)
+    for category in ("vectors", "pointclouds"):
+        for name, values in extents[category].items():
+            if not isinstance(name, str) or not isinstance(values, list):
+                raise ValueError("Invalid computed extent metadata")
+            values_to_check = values if category == "vectors" else [values]
+            for extent in values_to_check:
+                if not isinstance(extent, list) or len(extent) != 4:
+                    raise ValueError(f"Invalid computed extent metadata for {name}")
+                extent_values = tuple(float(value) for value in extent)
+                if not (bounds[0] <= extent_values[0] and bounds[1] <= extent_values[1] and extent_values[2] <= bounds[2] and extent_values[3] <= bounds[3]):
+                    raise ValueError(f"Computed extent for {name} exceeds the AOI plus 10 m")
     sources = manifest.get("sources")
     required = {"bag", "bgt", "top10nl", "cbs_key_figures", "cbs_buurtkaart"}
     if not isinstance(sources, Mapping):
@@ -253,6 +271,10 @@ def _laz(store, version, tile, pointcloud_store):
     destination.parent.mkdir(parents=True, exist_ok=True)
     if not destination.is_file() or destination.stat().st_size != source.stat().st_size:
         shutil.copy2(source, destination)
+    source_lax = source.with_suffix(".lax")
+    destination_lax = destination.with_suffix(".lax")
+    if source_lax.is_file() and (not destination_lax.is_file() or destination_lax.stat().st_size != source_lax.stat().st_size):
+        shutil.copy2(source_lax, destination_lax)
     digest = hashlib.sha256(destination.read_bytes()).hexdigest()
     expected = entry.get("sha256")
     if expected and digest != expected:

--- a/packages/core/src/bag3d/core/assets/input/tile.py
+++ b/packages/core/src/bag3d/core/assets/input/tile.py
@@ -8,6 +8,7 @@ from dagster import (
     AutomationCondition,
 )
 from pgutils import PostgresConnection
+from psycopg import connect
 from psycopg.errors import OperationalError, UndefinedTable
 from psycopg.sql import SQL, Identifier, Literal
 
@@ -42,6 +43,26 @@ def reconstruction_input_tiles(
     conn.send_query(
         SQL("CREATE SCHEMA IF NOT EXISTS {}").format(Identifier(output_schema))
     )
+
+    with connect(conn.dsn) as database:
+        row_count = database.execute(
+            SQL("SELECT COUNT(*) FROM {}").format(reconstruction_input.id)
+        ).fetchone()[0]
+    if row_count == 0:
+        tiles = Identifier(output_schema, "tiles")
+        index = Identifier(output_schema, "index")
+        conn.send_query(SQL("DROP TABLE IF EXISTS {}, {} CASCADE").format(index, tiles))
+        conn.send_query(
+            SQL("CREATE TABLE {} (tile_id TEXT, boundary geometry(Polygon, 28992))")
+            .format(tiles)
+        )
+        conn.send_query(
+            SQL("CREATE TABLE {} (fid BIGINT, tile_id TEXT)").format(index)
+        )
+        return (
+            Output(PostgresTableIdentifier(output_schema, "tiles"), output_name="tiles"),
+            Output(PostgresTableIdentifier(output_schema, "index"), output_name="index"),
+        )
 
     # todo: dirty hack just for now for removing sslmode, couz it's not implemented in tyler-db
     uri = conn.dsn.replace("sslmode=allow", "").strip()

--- a/packages/core/src/bag3d/core/assets/integration_data.py
+++ b/packages/core/src/bag3d/core/assets/integration_data.py
@@ -371,7 +371,27 @@ def integration_ahn6(
     )
 
 
-@asset(group_name="integration_data", automation_condition=AutomationCondition.eager())
+@asset(
+    group_name="integration_data",
+    automation_condition=AutomationCondition.eager(),
+    ins={
+        "extract_bag": AssetIn(key=AssetKey(["bag", "extract_bag"])),
+        "extract_bgt": AssetIn(key=AssetKey(["bgt", "extract_bgt"])),
+        "extract_top10nl": AssetIn(key=AssetKey(["top10nl", "extract_top10nl"])),
+        "extract_cbs_key_figures": AssetIn(
+            key=AssetKey(["cbs", "extract_cbs_key_figures"])
+        ),
+        "extract_cbs_buurtkaart": AssetIn(
+            key=AssetKey(["cbs", "extract_cbs_buurtkaart"])
+        ),
+        "tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"])),
+        "tile_index_ahn6": AssetIn(key=AssetKey(["ahn", "tile_index_ahn6"])),
+        "md5_ahn3": AssetIn(key=AssetKey(["ahn", "md5_ahn3"])),
+        "md5_ahn4": AssetIn(key=AssetKey(["ahn", "md5_ahn4"])),
+        "sha256_ahn5": AssetIn(key=AssetKey(["ahn", "sha256_ahn5"])),
+        "sha256_ahn6": AssetIn(key=AssetKey(["ahn", "sha256_ahn6"])),
+    },
+)
 def integration_manifest(
     integration_data_store: FileStoreResource,
     integration_bag,
@@ -383,15 +403,72 @@ def integration_manifest(
     integration_ahn4,
     integration_ahn5,
     integration_ahn6,
+    extract_bag,
+    extract_bgt,
+    extract_top10nl,
+    extract_cbs_key_figures,
+    extract_cbs_buurtkaart,
+    tile_index_ahn,
+    tile_index_ahn6,
+    md5_ahn3,
+    md5_ahn4,
+    sha256_ahn5,
+    sha256_ahn6,
 ) -> Path:
+    """Write the complete, versioned snapshot manifest used by fixture mode."""
     root = integration_data_store.path
-    files = sorted(
-        path
-        for path in root.rglob("*")
-        if path.is_file() and path.name != "manifest.json"
-    )
+    files = {}
+    for path in sorted(
+        p for p in root.rglob("*") if p.is_file() and p.name != "manifest.json"
+    ):
+        relative = str(path.relative_to(root))
+        files[relative] = {"size": path.stat().st_size}
+
+    def rel(path):
+        return str(Path(path).relative_to(root))
+
+    bag_dir = Path(integration_bag)
+    if not bag_dir.is_absolute():
+        bag_dir = root / bag_dir
+    bag_value = extract_bag if isinstance(extract_bag, tuple) else (extract_bag, {}, "")
+    sources = {
+        "bag": {
+            "path": rel(bag_dir),
+            "metadata": bag_value[1],
+            "shortdate": bag_value[2],
+        },
+        "bgt": {"path": rel(integration_bgt)},
+        "top10nl": {"path": rel(integration_top10nl)},
+        "cbs_key_figures": {"path": rel(integration_cbs_key_figures)},
+        "cbs_buurtkaart": {"path": rel(integration_cbs_buurtkaart)},
+    }
+    indexes = {"3": tile_index_ahn, "6": tile_index_ahn6}
+    checksums = {"3": md5_ahn3, "4": md5_ahn4, "5": sha256_ahn5, "6": sha256_ahn6}
+    partitions = {}
+    for version in (3, 4, 5):
+        version_dir = root / "pointclouds" / f"AHN{version}"
+        partitions[str(version)] = {}
+        for tile_id, entry in tile_index_ahn.items():
+            url = entry.get(f"AHN{version}_LAZ")
+            if url and (version_dir / Path(url).name).is_file():
+                partitions[str(version)][tile_id] = {
+                    "path": rel(version_dir / Path(url).name),
+                    "url": url,
+                }
+    partitions["6"] = {}
+    for tile_id, entry in tile_index_ahn6.items():
+        url = entry.get("url")
+        if url and (root / "pointclouds" / "AHN6" / Path(url).name).is_file():
+            batch = f"{int(tile_id.split('_')[0]) // 10000 * 10000:06d}_{int(tile_id.split('_')[1]) // 10000 * 10000:06d}"
+            partitions["6"].setdefault(batch, {})[tile_id] = {
+                "path": rel(root / "pointclouds" / "AHN6" / Path(url).name),
+                "url": url,
+            }
     manifest = {
+        "fixture_version": "1",
         "date": date.today().isoformat(),
-        "files": {str(path.relative_to(root)): path.stat().st_size for path in files},
+        "sources": sources,
+        "ahn": {"indexes": indexes, "checksums": checksums, "partitions": partitions},
+        "files": files,
     }
     return _write_json(root / "manifest.json", manifest)

--- a/packages/core/src/bag3d/core/assets/integration_data.py
+++ b/packages/core/src/bag3d/core/assets/integration_data.py
@@ -6,13 +6,14 @@ import re
 import shutil
 import sqlite3
 import tempfile
-import xml.etree.ElementTree as ET
 from datetime import date
+from io import BytesIO
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from dagster import AssetIn, AssetKey, AutomationCondition, Config, asset
+from lxml import etree
 from pydantic import Field
 
 from bag3d.common.resources.executables import GDALResource, LASToolsResource
@@ -25,6 +26,12 @@ AHN6_AOI_TILE_ALLOWLIST = [
     "122000_486000", "123000_485000", "123000_486000",
 ]
 _NUMBER = re.compile(r"-?\d+(?:\.\d+)?")
+_EXTENT = re.compile(r"Extent(?:\s+[^:]+)?:\s*\(([-+0-9.eE]+),\s*([-+0-9.eE]+)\)\s*-\s*\(([-+0-9.eE]+),\s*([-+0-9.eE]+)\)")
+_LAS_BOUND = re.compile(r"^\s*(min|max) x y z:\s*([-+0-9.eE]+)\s+([-+0-9.eE]+)", re.MULTILINE | re.IGNORECASE)
+_STAND_TAG = re.compile(rb"<(?:[A-Za-z_][\w.-]*:)?stand(?:\s|>)")
+_POS_TAG = re.compile(rb"<(?:[A-Za-z_][\w.-]*:)?pos(?:\s|>)")
+_AOI_COORDINATE = re.compile(rb"(?:^|\s)(?:12[12]\d{4}|123[0-3]\d{3})(?:\.\d+)?\s+(?:485[7-9]\d{2}|486[0-5]\d{2})(?:\.\d+)?(?:\s|$)")
+BUFFER_METRES = 10.0
 
 
 class IntegrationDataConfig(Config):
@@ -75,34 +82,87 @@ def ahn6_tiles_for_aoi(tile_index: Mapping[str, Mapping[str, Any]], geofilter: s
     return overlapping_tile_ids(tile_index, geofilter, allowlist)
 
 
-def _xml_bbox(data: bytes) -> tuple[float, float, float, float] | None:
-    values = [float(value) for value in _NUMBER.findall(data.decode("utf-8", errors="ignore"))]
-    pairs = [(x, y) for x, y in zip(values[0::2], values[1::2]) if 0 < x < 300000 and 0 < y < 700000]
-    if not pairs:
-        return None
-    return min(x for x, _ in pairs), min(y for _, y in pairs), max(x for x, _ in pairs), max(y for _, y in pairs)
-
-
 def _filter_bag_xml(data: bytes, aoi: tuple[float, float, float, float]) -> bytes | None:
-    try:
-        root = ET.fromstring(data)
-    except ET.ParseError:
-        bbox = _xml_bbox(data)
-        return data if bbox is None or _bbox_intersects(bbox, aoi) else None
-    children = list(root)
-    if not children:
-        bbox = _xml_bbox(data)
-        return data if bbox is None or _bbox_intersects(bbox, aoi) else None
-    removed = 0
-    for child in children:
-        bbox = _xml_bbox(ET.tostring(child, encoding="utf-8"))
-        if bbox is not None and not _bbox_intersects(bbox, aoi):
-            root.remove(child)
-            removed += 1
-    if removed == len(children):
+    if aoi == _aoi_bbox(AOI_WKT) and not _AOI_COORDINATE.search(data):
         return None
-    return ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    if not _STAND_TAG.search(data) and not _POS_TAG.search(data):
+        return data
+    try:
+        root = etree.fromstring(data)
+    except etree.XMLSyntaxError as exc:
+        raise ValueError("BAG XML is not well formed") from exc
+    stands = list(root.iter("{*}stand"))
+    buffered_aoi = (aoi[0] - BUFFER_METRES, aoi[1] - BUFFER_METRES, aoi[2] + BUFFER_METRES, aoi[3] + BUFFER_METRES)
+    if not stands:
+        features = [child for child in root if list(child.iter("{*}pos"))]
+        if not features:
+            return data
+        for feature in features:
+            coordinates = []
+            for pos in feature.iter("{*}pos"):
+                values = [float(value) for value in _NUMBER.findall(pos.text or "")]
+                dimension = int(pos.get("srsDimension", "3"))
+                if dimension < 2 or len(values) % dimension:
+                    coordinates = []
+                    break
+                coordinates.extend((values[index], values[index + 1]) for index in range(0, len(values), dimension))
+            if not coordinates:
+                root.remove(feature)
+                continue
+            bbox = (min(x for x, _ in coordinates), min(y for _, y in coordinates), max(x for x, _ in coordinates), max(y for _, y in coordinates))
+            if not _bbox_intersects(bbox, aoi) or not (buffered_aoi[0] <= bbox[0] and buffered_aoi[1] <= bbox[1] and bbox[2] <= buffered_aoi[2] and bbox[3] <= buffered_aoi[3]):
+                root.remove(feature)
+        return etree.tostring(root, encoding="UTF-8", xml_declaration=True) if any(root.iter("{*}pos")) else None
+    for stand in stands:
+        coordinates: list[tuple[float, float]] = []
+        valid_geometry = True
+        for pos_list in stand.iter("{*}posList"):
+            values = [float(value) for value in _NUMBER.findall(pos_list.text or "")]
+            dimension_value = pos_list.get("srsDimension")
+            if dimension_value is None:
+                dimension = 3 if len(values) % 3 == 0 else 2
+            else:
+                try:
+                    dimension = int(dimension_value)
+                except ValueError:
+                    valid_geometry = False
+                    break
+            if dimension < 2 or len(values) % dimension:
+                valid_geometry = False
+                break
+            coordinates.extend((values[index], values[index + 1]) for index in range(0, len(values), dimension))
+        if not valid_geometry:
+            parent = stand.getparent()
+            if parent is not None:
+                parent.remove(stand)
+            continue
+        if not coordinates:
+            parent = stand.getparent()
+            if parent is not None:
+                parent.remove(stand)
+            continue
+        bbox = (min(x for x, _ in coordinates), min(y for _, y in coordinates), max(x for x, _ in coordinates), max(y for _, y in coordinates))
+        if not _bbox_intersects(bbox, aoi) or not (buffered_aoi[0] <= bbox[0] and buffered_aoi[1] <= bbox[1] and bbox[2] <= buffered_aoi[2] and bbox[3] <= buffered_aoi[3]):
+            parent = stand.getparent()
+            if parent is not None:
+                parent.remove(stand)
+    if not any(root.iter("{*}stand")):
+        return None
+    return etree.tostring(root, encoding="UTF-8", xml_declaration=True)
 
+
+def _filter_bag_member(data: bytes, aoi: tuple[float, float, float, float], filename: str) -> bytes | None:
+    if filename.lower().endswith(".zip"):
+        output = BytesIO()
+        with ZipFile(BytesIO(data)) as source_zip, ZipFile(output, "w", ZIP_DEFLATED) as target_zip:
+            for info in source_zip.infolist():
+                member = _filter_bag_member(source_zip.read(info), aoi, info.filename)
+                if member is not None:
+                    target_zip.writestr(info, member)
+        return output.getvalue() if output.tell() else None
+    if filename.lower().endswith((".xml", ".gml")) and data.strip():
+        return _filter_bag_xml(data, aoi)
+    return data
 
 def filter_bag_extract(source: Path, destination: Path, geofilter: str = AOI_WKT) -> Path:
     aoi = _aoi_bbox(geofilter)
@@ -112,14 +172,14 @@ def filter_bag_extract(source: Path, destination: Path, geofilter: str = AOI_WKT
         if source_file.suffix.lower() != ".zip":
             shutil.copy2(source_file, target)
             continue
+        if re.search(r"(?:NUM|OPR|RELATIE)", source_file.name.upper()):
+            shutil.copy2(source_file, target)
+            continue
         with ZipFile(source_file) as source_zip, ZipFile(target, "w", ZIP_DEFLATED) as target_zip:
             for info in source_zip.infolist():
-                data = source_zip.read(info)
-                if info.filename.lower().endswith((".xml", ".gml")):
-                    data = _filter_bag_xml(data, aoi)
-                    if data is None:
-                        continue
-                target_zip.writestr(info, data)
+                data = _filter_bag_member(source_zip.read(info), aoi, info.filename)
+                if data is not None:
+                    target_zip.writestr(info, data)
     return destination
 
 
@@ -187,7 +247,7 @@ def integration_bag(config: IntegrationDataConfig, integration_data_store: FileS
 
 @asset(group_name="integration_data", ins={"extract_bgt": AssetIn(key=AssetKey(["bgt", "extract_bgt"]))}, automation_condition=AutomationCondition.eager())
 def integration_bgt(config: IntegrationDataConfig, integration_data_store: FileStoreResource, extract_bgt, gdal: GDALResource) -> Path:
-    return _clip_gml_archive(Path(extract_bgt), integration_data_store.path / "bgt" / "bgt.zip", ("bgt_pand.gml", "bgt_pand.gml"), "bgt_pand.gml", config.geofilter, gdal)
+    return _clip_gml_archive(Path(extract_bgt), integration_data_store.path / "bgt" / "bgt.zip", ("bgt_pand.gml",), "bgt_pand.gml", config.geofilter, gdal)
 
 
 @asset(group_name="integration_data", ins={"extract_top10nl": AssetIn(key=AssetKey(["top10nl", "extract_top10nl"]))}, automation_condition=AutomationCondition.eager())
@@ -254,9 +314,108 @@ def integration_ahn6(config: IntegrationDataConfig, integration_data_store: File
     return _download_ahn_tiles(tile_index_ahn6, 6, integration_data_store.path / "pointclouds", config.geofilter, lastools, config.ahn6_allowlist)
 
 
+def _command_has_gdal_error(result: Any) -> bool:
+    return result.returncode != 0 or bool(re.search(r"(?im)^\s*(?:error|fatal|critical)\b", result.stdout + result.stderr))
+
+
+def _ogrinfo_extents(gdal_runner: Any, path: Path, require_extent: bool = True) -> list[tuple[float, float, float, float]]:
+    result = gdal_runner.run("{exe} -so -al '{local_path}'", exe_name="ogrinfo", local_path=path)
+    if _command_has_gdal_error(result):
+        raise RuntimeError(f"ogrinfo failed for {path}: {result.stderr or result.stdout}")
+    extents = [tuple(float(value) for value in match) for match in _EXTENT.findall(result.stdout)]
+    if not extents and require_extent:
+        raise RuntimeError(f"ogrinfo returned no extent for {path}")
+    return extents
+
+
+def _ogrinfo_xml(gdal_runner: Any, data: bytes, suffix: str, require_extent: bool = True) -> list[tuple[float, float, float, float]]:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        path = Path(temp_dir) / Path(suffix).name
+        path.write_bytes(data)
+        return _ogrinfo_extents(gdal_runner, path, require_extent)
+
+
+def _nested_bag_xml(data: bytes, prefix: str = "") -> Iterable[tuple[str, bytes]]:
+    with ZipFile(BytesIO(data)) as archive:
+        for info in archive.infolist():
+            member = archive.read(info)
+            name = f"{prefix}!{info.filename}" if prefix else info.filename
+            if info.filename.lower().endswith(".zip"):
+                yield from _nested_bag_xml(member, name)
+            elif info.filename.lower().endswith((".xml", ".gml")) and member.strip():
+                yield name, member
+
+
+def _is_spatial_bag_xml(data: bytes) -> bool:
+    return bool(_STAND_TAG.search(data) or _POS_TAG.search(data))
+
+
+def _buffered_extent(aoi: tuple[float, float, float, float]) -> tuple[float, float, float, float]:
+    return (aoi[0] - BUFFER_METRES, aoi[1] - BUFFER_METRES, aoi[2] + BUFFER_METRES, aoi[3] + BUFFER_METRES)
+
+
+def _validate_extent(extent: tuple[float, float, float, float], allowed: tuple[float, float, float, float], label: str) -> None:
+    if not (allowed[0] <= extent[0] and allowed[1] <= extent[1] and extent[2] <= allowed[2] and extent[3] <= allowed[3]):
+        raise ValueError(f"Extent for {label} is outside the AOI plus {BUFFER_METRES:g} m: {extent}")
+
+
+def _validate_outputs(root: Path, bag: Path, bgt: Path, top10nl: Path, cbs: Path, ahn_roots: Iterable[Path], aoi: tuple[float, float, float, float], gdal: GDALResource, lastools: LASToolsResource) -> dict[str, Any]:
+    allowed = _buffered_extent(aoi)
+    gdal_runner = gdal.runner
+    vector_extents: dict[str, list[list[float]]] = {}
+    for archive in sorted(bag.rglob("*.zip")):
+        for name, data in _nested_bag_xml(archive.read_bytes(), str(archive.relative_to(root))):
+            if not _is_spatial_bag_xml(data):
+                continue
+            extents = [_validate_and_return(extent, allowed, f"{archive.name}!{name}") for extent in _ogrinfo_xml(gdal_runner, data, name, require_extent=False)]
+            vector_extents[f"{archive.name}!{name}"] = [list(extent) for extent in extents]
+    for path in sorted(bag.rglob("*")):
+        if path.is_file() and path.suffix.lower() in {".xml", ".gml"} and path.stat().st_size:
+            data = path.read_bytes()
+            if not _is_spatial_bag_xml(data):
+                continue
+            extents = [_validate_and_return(extent, allowed, str(path.relative_to(root))) for extent in _ogrinfo_extents(gdal_runner, path)]
+            vector_extents[str(path.relative_to(root))] = [list(extent) for extent in extents]
+
+    for archive, layer_names in ((bgt, ("bgt_pand.gml",)), (top10nl, ("top10nl_gebouw.gml",))):
+        member = _archive_layer(archive, layer_names)
+        with ZipFile(archive) as source_zip:
+            data = source_zip.read(member)
+        extents = [_validate_and_return(extent, allowed, f"{archive}!{member}") for extent in _ogrinfo_xml(gdal_runner, data, member)]
+        vector_extents[str(archive.relative_to(root))] = [list(extent) for extent in extents]
+
+    extents = [_validate_and_return(extent, allowed, str(cbs)) for extent in _ogrinfo_extents(gdal_runner, cbs)]
+    vector_extents[str(cbs.relative_to(root))] = [list(extent) for extent in extents]
+
+    pointcloud_extents: dict[str, list[float]] = {}
+    lastools_runner = lastools.runner
+    for pointcloud_root in ahn_roots:
+        for path in sorted(pointcloud_root.rglob("*")):
+            if path.suffix.lower() not in {".las", ".laz"}:
+                continue
+            result = lastools_runner.run("{exe} -i '{local_path}'", exe_name="lasinfo", local_path=path)
+            if result.returncode != 0 or bool(re.search(r"(?im)^\s*(?:error|fatal|critical)\b", result.stdout + result.stderr)):
+                raise RuntimeError(f"lasinfo failed for {path}: {result.stderr or result.stdout}")
+            las_output = result.stdout + result.stderr
+            bounds = {kind: (float(x), float(y)) for kind, x, y in _LAS_BOUND.findall(las_output)}
+            if set(bounds) != {"min", "max"}:
+                raise RuntimeError(f"lasinfo returned no complete XY bounds for {path}")
+            extent = (bounds["min"][0], bounds["min"][1], bounds["max"][0], bounds["max"][1])
+            _validate_extent(extent, allowed, str(path.relative_to(root)))
+            pointcloud_extents[str(path.relative_to(root))] = list(extent)
+    return {"buffer_metres": BUFFER_METRES, "extents": {"vectors": vector_extents, "pointclouds": pointcloud_extents}}
+
+
+def _validate_and_return(extent: tuple[float, float, float, float], allowed: tuple[float, float, float, float], label: str) -> tuple[float, float, float, float]:
+    _validate_extent(extent, allowed, label)
+    return extent
+
+
 @asset(group_name="integration_data", automation_condition=AutomationCondition.eager(), ins={"extract_bag": AssetIn(key=AssetKey(["bag", "extract_bag"])), "extract_bgt": AssetIn(key=AssetKey(["bgt", "extract_bgt"])), "extract_top10nl": AssetIn(key=AssetKey(["top10nl", "extract_top10nl"])), "extract_cbs_key_figures": AssetIn(key=AssetKey(["cbs", "extract_cbs_key_figures"])), "extract_cbs_buurtkaart": AssetIn(key=AssetKey(["cbs", "extract_cbs_buurtkaart"])), "tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"])), "tile_index_ahn6": AssetIn(key=AssetKey(["ahn", "tile_index_ahn6"])), "md5_ahn3": AssetIn(key=AssetKey(["ahn", "md5_ahn3"])), "md5_ahn4": AssetIn(key=AssetKey(["ahn", "md5_ahn4"])), "sha256_ahn5": AssetIn(key=AssetKey(["ahn", "sha256_ahn5"])), "sha256_ahn6": AssetIn(key=AssetKey(["ahn", "sha256_ahn6"]))})
-def integration_manifest(integration_data_store: FileStoreResource, integration_bag, integration_bgt, integration_top10nl, integration_cbs_key_figures, integration_cbs_buurtkaart, integration_ahn3, integration_ahn4, integration_ahn5, integration_ahn6, extract_bag, extract_bgt, extract_top10nl, extract_cbs_key_figures, extract_cbs_buurtkaart, tile_index_ahn, tile_index_ahn6, md5_ahn3, md5_ahn4, sha256_ahn5, sha256_ahn6) -> Path:
+def integration_manifest(integration_data_store: FileStoreResource, integration_bag, integration_bgt, integration_top10nl, integration_cbs_key_figures, integration_cbs_buurtkaart, integration_ahn3, integration_ahn4, integration_ahn5, integration_ahn6, extract_bag, extract_bgt, extract_top10nl, extract_cbs_key_figures, extract_cbs_buurtkaart, tile_index_ahn, tile_index_ahn6, md5_ahn3, md5_ahn4, sha256_ahn5, sha256_ahn6, gdal: GDALResource, lastools: LASToolsResource) -> Path:
     root = integration_data_store.path
+    aoi = _aoi_bbox(AOI_WKT)
+    validation = _validate_outputs(root, Path(integration_bag), Path(integration_bgt), Path(integration_top10nl), Path(integration_cbs_buurtkaart), (Path(integration_ahn3), Path(integration_ahn4), Path(integration_ahn5), Path(integration_ahn6)), aoi, gdal, lastools)
     files: dict[str, dict[str, Any]] = {}
     for path in sorted(path for path in root.rglob("*") if path.is_file() and path.name != "manifest.json"):
         digest = hashlib.sha256(path.read_bytes()).hexdigest()
@@ -278,5 +437,5 @@ def integration_manifest(integration_data_store: FileStoreResource, integration_
             x, y = (int(value) for value in tile_id.split("_"))
             batch = f"{x // 10000 * 10000:06d}_{y // 10000 * 10000:06d}"
             partitions["6"].setdefault(batch, {})[tile_id] = {"path": rel(path), "url": entry["url"], "size": path.stat().st_size, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
-    manifest = {"fixture_version": "2", "date": date.today().isoformat(), "aoi": {"wkt": AOI_WKT, "minx": 121967, "miny": 485750, "maxx": 123354, "maxy": 486550}, "clipping": {"vectors": "gdal", "pointclouds": "las2las_keep_xy"}, "sources": sources, "ahn": {"indexes": {"3": tile_index_ahn, "6": tile_index_ahn6}, "checksums": {"3": md5_ahn3, "4": md5_ahn4, "5": sha256_ahn5, "6": sha256_ahn6}, "partitions": partitions}, "files": files}
+    manifest = {"fixture_version": "2", "date": date.today().isoformat(), "aoi": {"wkt": AOI_WKT, "minx": aoi[0], "miny": aoi[1], "maxx": aoi[2], "maxy": aoi[3]}, "clipping": {"vectors": "gdal", "pointclouds": "las2las_keep_xy"}, "validation": validation, "sources": sources, "ahn": {"indexes": {"3": tile_index_ahn, "6": tile_index_ahn6}, "checksums": {"3": md5_ahn3, "4": md5_ahn4, "5": sha256_ahn5, "6": sha256_ahn6}, "partitions": partitions}, "files": files}
     return _write_json(root / "manifest.json", manifest)

--- a/packages/core/src/bag3d/core/assets/integration_data.py
+++ b/packages/core/src/bag3d/core/assets/integration_data.py
@@ -30,7 +30,7 @@ _EXTENT = re.compile(r"Extent(?:\s+[^:]+)?:\s*\(([-+0-9.eE]+),\s*([-+0-9.eE]+)\)
 _LAS_BOUND = re.compile(r"^\s*(min|max) x y z:\s*([-+0-9.eE]+)\s+([-+0-9.eE]+)", re.MULTILINE | re.IGNORECASE)
 _STAND_TAG = re.compile(rb"<(?:[A-Za-z_][\w.-]*:)?stand(?:\s|>)")
 _POS_TAG = re.compile(rb"<(?:[A-Za-z_][\w.-]*:)?pos(?:\s|>)")
-_AOI_COORDINATE = re.compile(rb"(?:^|\s)(?:12[12]\d{4}|123[0-3]\d{3})(?:\.\d+)?\s+(?:485[7-9]\d{2}|486[0-5]\d{2})(?:\.\d+)?(?:\s|$)")
+_AOI_COORDINATE = re.compile(rb"(?:^|\s)(?:12[12]\d{3}|123[0-3]\d{2})(?:\.\d+)?\s+(?:485[7-9]\d{2}|486[0-5]\d{2})(?:\.\d+)?(?:\s|$)")
 BUFFER_METRES = 10.0
 
 

--- a/packages/core/src/bag3d/core/assets/integration_data.py
+++ b/packages/core/src/bag3d/core/assets/integration_data.py
@@ -1,13 +1,12 @@
-"""Monthly, small-area source-data fixtures.
+"""AOI-subset source-data fixtures for integration and pipeline tests."""
 
-The assets in this module deliberately write files instead of loading data into
-PostgreSQL.  The resulting directory is a portable test fixture and its manifest
-is the commit marker for a complete snapshot.
-"""
-
+import hashlib
 import json
 import re
 import shutil
+import sqlite3
+import tempfile
+import xml.etree.ElementTree as ET
 from datetime import date
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -16,166 +15,140 @@ from zipfile import ZIP_DEFLATED, ZipFile
 from dagster import AssetIn, AssetKey, AutomationCondition, Config, asset
 from pydantic import Field
 
+from bag3d.common.resources.executables import GDALResource, LASToolsResource
 from bag3d.common.resources.files import FileStoreResource
-from bag3d.common.resources.executables import GDALResource
 from bag3d.common.utils.requests import download_file
 
 AOI_WKT = "POLYGON ((121967 485750, 123354 485750, 123354 486550, 121967 486550, 121967 485750))"
 AHN6_AOI_TILE_ALLOWLIST = [
-    "121000_485000",
-    "121000_486000",
-    "122000_485000",
-    "122000_486000",
-    "123000_485000",
-    "123000_486000",
+    "121000_485000", "121000_486000", "122000_485000",
+    "122000_486000", "123000_485000", "123000_486000",
 ]
 _NUMBER = re.compile(r"-?\d+(?:\.\d+)?")
 
 
 class IntegrationDataConfig(Config):
-    """Configuration shared by the fixture assets."""
-
     geofilter: str = Field(default=AOI_WKT)
     cbs_year: str = Field(default="2025")
-    ahn6_allowlist: list[str] = Field(
-        default_factory=lambda: AHN6_AOI_TILE_ALLOWLIST.copy()
-    )
+    ahn6_allowlist: list[str] = Field(default_factory=lambda: AHN6_AOI_TILE_ALLOWLIST.copy())
 
 
 def _aoi_bbox(wkt: str) -> tuple[float, float, float, float]:
-    values = [float(v) for v in _NUMBER.findall(wkt)]
-    if len(values) < 8:
+    if not re.match(r"^\s*POLYGON\s*\(\(", wkt, re.IGNORECASE):
         raise ValueError(f"Expected a polygon WKT, got {wkt!r}")
+    values = [float(value) for value in _NUMBER.findall(wkt)]
     points = list(zip(values[0::2], values[1::2]))
-    return (
-        min(x for x, _ in points),
-        min(y for _, y in points),
-        max(x for x, _ in points),
-        max(y for _, y in points),
-    )
+    if len(points) < 4 or points[0] != points[-1]:
+        raise ValueError(f"Expected a closed polygon WKT, got {wkt!r}")
+    extent = (min(x for x, _ in points), min(y for _, y in points), max(x for x, _ in points), max(y for _, y in points))
+    if extent[0] >= extent[2] or extent[1] >= extent[3]:
+        raise ValueError(f"Polygon WKT has no area: {wkt!r}")
+    return extent
 
 
-def _bbox_intersects(
-    a: tuple[float, float, float, float], b: tuple[float, float, float, float]
-) -> bool:
-    """Return true only for positive-area intersection."""
+def _bbox_intersects(a: tuple[float, float, float, float], b: tuple[float, float, float, float]) -> bool:
     return max(a[0], b[0]) < min(a[2], b[2]) and max(a[1], b[1]) < min(a[3], b[3])
 
 
 def _geometry_bbox(geometry: Mapping[str, Any]) -> tuple[float, float, float, float]:
-    coordinates = geometry.get("coordinates", [])
     values: list[float] = []
-
     def visit(value: Any) -> None:
         if isinstance(value, (list, tuple)):
-            if len(value) >= 2 and all(isinstance(v, (int, float)) for v in value[:2]):
+            if len(value) >= 2 and all(isinstance(item, (int, float)) for item in value[:2]):
                 values.extend((float(value[0]), float(value[1])))
             else:
                 for child in value:
                     visit(child)
-
-    visit(coordinates)
+    visit(geometry.get("coordinates", []))
     if len(values) < 2:
         raise ValueError("Geometry has no coordinates")
     return min(values[0::2]), min(values[1::2]), max(values[0::2]), max(values[1::2])
 
 
-def overlapping_tile_ids(
-    tile_index: Mapping[str, Mapping[str, Any]],
-    geofilter: str = AOI_WKT,
-    allowlist: Iterable[str] | None = None,
-) -> list[str]:
-    """Select tile IDs whose indexed geometry overlaps the AOI."""
+def overlapping_tile_ids(tile_index: Mapping[str, Mapping[str, Any]], geofilter: str = AOI_WKT, allowlist: Iterable[str] | None = None) -> list[str]:
     aoi = _aoi_bbox(geofilter)
     allowed = set(allowlist) if allowlist is not None else None
-    selected = []
-    for tile_id, entry in tile_index.items():
-        if allowed is not None and tile_id not in allowed:
-            continue
-        geometry = entry.get("geometry")
-        if geometry and _bbox_intersects(_geometry_bbox(geometry), aoi):
-            selected.append(tile_id)
-    return sorted(selected)
+    return sorted(tile_id for tile_id, entry in tile_index.items() if (allowed is None or tile_id in allowed) and entry.get("geometry") and _bbox_intersects(_geometry_bbox(entry["geometry"]), aoi))
 
 
-def ahn6_tiles_for_aoi(
-    tile_index: Mapping[str, Mapping[str, Any]],
-    geofilter: str = AOI_WKT,
-    allowlist: Iterable[str] = (),
-) -> list[str]:
-    """Select AOI tiles from AHN6, applying the explicit fixture allowlist."""
+def ahn6_tiles_for_aoi(tile_index: Mapping[str, Mapping[str, Any]], geofilter: str = AOI_WKT, allowlist: Iterable[str] = ()) -> list[str]:
     return overlapping_tile_ids(tile_index, geofilter, allowlist)
 
 
 def _xml_bbox(data: bytes) -> tuple[float, float, float, float] | None:
-    values = [float(v) for v in _NUMBER.findall(data.decode("utf-8", errors="ignore"))]
-    if len(values) < 4:
-        return None
-    # BAG geometries use x/y pairs; metadata values can also be present, so use
-    # the complete coordinate envelope only when it is in the RD New range.
-    pairs = list(zip(values[0::2], values[1::2]))
-    pairs = [(x, y) for x, y in pairs if 0 < x < 300000 and 0 < y < 700000]
+    values = [float(value) for value in _NUMBER.findall(data.decode("utf-8", errors="ignore"))]
+    pairs = [(x, y) for x, y in zip(values[0::2], values[1::2]) if 0 < x < 300000 and 0 < y < 700000]
     if not pairs:
         return None
-    return (
-        min(x for x, _ in pairs),
-        min(y for _, y in pairs),
-        max(x for x, _ in pairs),
-        max(y for _, y in pairs),
-    )
+    return min(x for x, _ in pairs), min(y for _, y in pairs), max(x for x, _ in pairs), max(y for _, y in pairs)
 
 
-def filter_bag_extract(
-    source: Path, destination: Path, geofilter: str = AOI_WKT
-) -> Path:
-    """Copy a BAG extract while retaining its nested ZIP/XML layout."""
-    destination.mkdir(parents=True, exist_ok=True)
+def _filter_bag_xml(data: bytes, aoi: tuple[float, float, float, float]) -> bytes | None:
+    try:
+        root = ET.fromstring(data)
+    except ET.ParseError:
+        bbox = _xml_bbox(data)
+        return data if bbox is None or _bbox_intersects(bbox, aoi) else None
+    children = list(root)
+    if not children:
+        bbox = _xml_bbox(data)
+        return data if bbox is None or _bbox_intersects(bbox, aoi) else None
+    removed = 0
+    for child in children:
+        bbox = _xml_bbox(ET.tostring(child, encoding="utf-8"))
+        if bbox is not None and not _bbox_intersects(bbox, aoi):
+            root.remove(child)
+            removed += 1
+    if removed == len(children):
+        return None
+    return ET.tostring(root, encoding="utf-8", xml_declaration=True)
+
+
+def filter_bag_extract(source: Path, destination: Path, geofilter: str = AOI_WKT) -> Path:
     aoi = _aoi_bbox(geofilter)
+    destination.mkdir(parents=True, exist_ok=True)
     for source_file in source.iterdir():
         target = destination / source_file.name
         if source_file.suffix.lower() != ".zip":
             shutil.copy2(source_file, target)
             continue
-        with (
-            ZipFile(source_file) as source_zip,
-            ZipFile(target, "w", ZIP_DEFLATED) as target_zip,
-        ):
+        with ZipFile(source_file) as source_zip, ZipFile(target, "w", ZIP_DEFLATED) as target_zip:
             for info in source_zip.infolist():
                 data = source_zip.read(info)
                 if info.filename.lower().endswith((".xml", ".gml")):
-                    bbox = _xml_bbox(data)
-                    if bbox is not None and not _bbox_intersects(bbox, aoi):
+                    data = _filter_bag_xml(data, aoi)
+                    if data is None:
                         continue
                 target_zip.writestr(info, data)
     return destination
 
 
-def matching_cbs_codes(
-    records: Iterable[Mapping[str, Any]],
-    geometries: Mapping[str, Mapping[str, Any]],
-    geofilter: str = AOI_WKT,
-) -> list[dict[str, Any]]:
-    """Keep key figures for intersecting gemeente, wijk, and buurt codes."""
-    aoi = _aoi_bbox(geofilter)
-    codes = {
-        code
-        for code, feature in geometries.items()
-        if feature.get("geometry")
-        and _bbox_intersects(_geometry_bbox(feature["geometry"]), aoi)
-    }
-    result = []
-    for record in records:
-        code = next(
-            (
-                record.get(key)
-                for key in ("Codering", "Code", "code", "BU_CODE", "RegioS")
-                if record.get(key)
-            ),
-            None,
+def _archive_layer(source: Path, names: tuple[str, ...]) -> str:
+    with ZipFile(source) as archive:
+        members = archive.namelist()
+    for wanted in names:
+        for member in members:
+            if member.lower() == wanted.lower() or member.lower().endswith(wanted.lower()):
+                return member
+    raise FileNotFoundError(f"Archive {source} does not contain one of {names}")
+
+
+def _clip_gml_archive(source: Path, destination: Path, layer_names: tuple[str, ...], output_name: str, geofilter: str, gdal: GDALResource) -> Path:
+    _aoi_bbox(geofilter)
+    member = _archive_layer(source, layer_names)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=destination.parent) as temp_dir:
+        output = Path(temp_dir) / output_name
+        result = gdal.runner.run(
+            "{exe} -f GML -clipsrc '{aoi}' '{output}' '{input_path}'",
+            exe_name="ogr2ogr",
+            kwargs={"aoi": geofilter, "output": output, "input_path": f"/vsizip/{source}/{member}"},
         )
-        if code is not None and str(code) in codes:
-            result.append(dict(record))
-    return result
+        if not result.success or not output.is_file():
+            raise RuntimeError(f"Could not clip {source.name}: {result.stderr}")
+        with ZipFile(destination, "w", ZIP_DEFLATED) as archive:
+            archive.write(output, output_name)
+    return destination
 
 
 def _copy_download(url: str, target_dir: Path) -> Path:
@@ -191,284 +164,119 @@ def _write_json(path: Path, value: Any) -> Path:
     return path
 
 
-@asset(
-    group_name="integration_data",
-    ins={"extract_bag": AssetIn(key=AssetKey(["bag", "extract_bag"]))},
-    automation_condition=AutomationCondition.eager(),
-)
-def integration_bag(
-    config: IntegrationDataConfig,
-    integration_data_store: FileStoreResource,
-    extract_bag,
-) -> Path:
+def _codes_from_clipped_buurtkaart(path: Path) -> set[str]:
+    codes: set[str] = set()
+    with sqlite3.connect(path) as connection:
+        tables = connection.execute("SELECT table_name FROM gpkg_contents WHERE data_type = 'features'").fetchall()
+        for (table,) in tables:
+            columns = [row[1] for row in connection.execute(f'PRAGMA table_info("{table}")')]
+            code_columns = [column for column in columns if any(token in column.lower() for token in ("code", "codering", "regio"))]
+            if not code_columns:
+                continue
+            selected = ", ".join(f'"{column}"' for column in code_columns)
+            for row in connection.execute(f'SELECT {selected} FROM "{table}"'):
+                codes.update(str(value).strip() for value in row if value is not None)
+    return codes
+
+
+@asset(group_name="integration_data", ins={"extract_bag": AssetIn(key=AssetKey(["bag", "extract_bag"]))}, automation_condition=AutomationCondition.eager())
+def integration_bag(config: IntegrationDataConfig, integration_data_store: FileStoreResource, extract_bag) -> Path:
     source = Path(extract_bag[0] if isinstance(extract_bag, tuple) else extract_bag)
-    return filter_bag_extract(
-        source, integration_data_store.path / "bag", config.geofilter
-    )
+    return filter_bag_extract(source, integration_data_store.path / "bag", config.geofilter)
 
 
-@asset(
-    group_name="integration_data",
-    ins={"extract_bgt": AssetIn(key=AssetKey(["bgt", "extract_bgt"]))},
-    automation_condition=AutomationCondition.eager(),
-)
-def integration_bgt(integration_data_store: FileStoreResource, extract_bgt) -> Path:
-    target = integration_data_store.path / "bgt" / Path(extract_bgt).name
-    target.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(extract_bgt, target)
-    return target
+@asset(group_name="integration_data", ins={"extract_bgt": AssetIn(key=AssetKey(["bgt", "extract_bgt"]))}, automation_condition=AutomationCondition.eager())
+def integration_bgt(config: IntegrationDataConfig, integration_data_store: FileStoreResource, extract_bgt, gdal: GDALResource) -> Path:
+    return _clip_gml_archive(Path(extract_bgt), integration_data_store.path / "bgt" / "bgt.zip", ("bgt_pand.gml", "bgt_pand.gml"), "bgt_pand.gml", config.geofilter, gdal)
 
 
-@asset(
-    group_name="integration_data",
-    ins={"extract_top10nl": AssetIn(key=AssetKey(["top10nl", "extract_top10nl"]))},
-    automation_condition=AutomationCondition.eager(),
-)
-def integration_top10nl(
-    integration_data_store: FileStoreResource, extract_top10nl
-) -> Path:
-    target = integration_data_store.path / "top10nl" / Path(extract_top10nl).name
-    target.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(extract_top10nl, target)
-    return target
+@asset(group_name="integration_data", ins={"extract_top10nl": AssetIn(key=AssetKey(["top10nl", "extract_top10nl"]))}, automation_condition=AutomationCondition.eager())
+def integration_top10nl(config: IntegrationDataConfig, integration_data_store: FileStoreResource, extract_top10nl, gdal: GDALResource) -> Path:
+    return _clip_gml_archive(Path(extract_top10nl), integration_data_store.path / "top10nl" / "top10nl.zip", ("top10nl_gebouw.gml",), "top10nl_gebouw.gml", config.geofilter, gdal)
 
 
-@asset(
-    group_name="integration_data",
-    ins={
-        "extract_cbs_key_figures": AssetIn(
-            key=AssetKey(["cbs", "extract_cbs_key_figures"])
-        )
-    },
-    automation_condition=AutomationCondition.eager(),
-)
-def integration_cbs_key_figures(
-    integration_data_store: FileStoreResource, extract_cbs_key_figures
-) -> Path:
-    target = integration_data_store.path / "cbs" / "key_figures.json"
-    return _write_json(target, extract_cbs_key_figures)
+@asset(group_name="integration_data", ins={"extract_cbs_key_figures": AssetIn(key=AssetKey(["cbs", "extract_cbs_key_figures"])), "clipped_buurtkaart": AssetIn(key=AssetKey(["integration_cbs_buurtkaart"]))}, automation_condition=AutomationCondition.eager())
+def integration_cbs_key_figures(config: IntegrationDataConfig, integration_data_store: FileStoreResource, extract_cbs_key_figures, clipped_buurtkaart) -> Path:
+    codes = _codes_from_clipped_buurtkaart(Path(clipped_buurtkaart))
+    records = [record for record in extract_cbs_key_figures if any(str(record.get(key, "")).strip() in codes for key in ("Codering", "Code", "code", "BU_CODE", "RegioS"))]
+    return _write_json(integration_data_store.path / "cbs" / "key_figures.json", records)
 
 
-@asset(
-    group_name="integration_data",
-    ins={
-        "extract_cbs_buurtkaart": AssetIn(
-            key=AssetKey(["cbs", "extract_cbs_buurtkaart"])
-        )
-    },
-    automation_condition=AutomationCondition.eager(),
-)
-def integration_cbs_buurtkaart(
-    integration_data_store: FileStoreResource,
-    extract_cbs_buurtkaart,
-    gdal: GDALResource,
-) -> Path:
+@asset(group_name="integration_data", ins={"extract_cbs_buurtkaart": AssetIn(key=AssetKey(["cbs", "extract_cbs_buurtkaart"]))}, automation_condition=AutomationCondition.eager())
+def integration_cbs_buurtkaart(config: IntegrationDataConfig, integration_data_store: FileStoreResource, extract_cbs_buurtkaart, gdal: GDALResource) -> Path:
+    _aoi_bbox(config.geofilter)
     target = integration_data_store.path / "cbs" / "buurtkaart.gpkg"
     target.parent.mkdir(parents=True, exist_ok=True)
-    result = gdal.runner.run(
-        "{exe} -f GPKG -clipsrc '{aoi}' '{output}' '{local_path}'",
-        exe_name="ogr2ogr",
-        kwargs={"aoi": AOI_WKT, "output": target},
-        local_path=Path(extract_cbs_buurtkaart),
-    )
-    if not result.success:
+    if target.exists():
+        target.unlink()
+    result = gdal.runner.run("{exe} -f GPKG -clipsrc '{aoi}' '{output}' '{source}'", exe_name="ogr2ogr", kwargs={"aoi": config.geofilter, "output": target, "source": Path(extract_cbs_buurtkaart)})
+    if not result.success or not target.is_file():
         raise RuntimeError(f"Could not clip buurtkaart: {result.stderr}")
     return target
 
 
-def _download_ahn_tiles(
-    index: Mapping[str, Mapping[str, Any]],
-    versions: Iterable[int],
-    target: Path,
-    geofilter: str,
-    allowlist: Iterable[str] = (),
-) -> Path:
-    target.mkdir(parents=True, exist_ok=True)
-    for version in versions:
-        selected = overlapping_tile_ids(
-            index, geofilter, allowlist if version == 6 else None
-        )
-        version_dir = target / f"AHN{version}"
-        version_dir.mkdir(exist_ok=True)
-        for tile_id in selected:
-            entry = index[tile_id]
-            url = entry.get("url") if version == 6 else entry.get(f"AHN{version}_LAZ")
-            if url:
-                _copy_download(url, version_dir)
+def _download_ahn_tiles(index: Mapping[str, Mapping[str, Any]], version: int, target: Path, geofilter: str, lastools: LASToolsResource, allowlist: Iterable[str] = ()) -> Path:
+    selected = overlapping_tile_ids(index, geofilter, allowlist if version == 6 else None)
+    version_dir = target / f"AHN{version}"
+    version_dir.mkdir(parents=True, exist_ok=True)
+    minx, miny, maxx, maxy = _aoi_bbox(geofilter)
+    for tile_id in selected:
+        entry = index[tile_id]
+        url = entry.get("url") if version == 6 else entry.get(f"AHN{version}_LAZ")
+        if not url:
+            continue
+        with tempfile.TemporaryDirectory(dir=target) as temp_dir:
+            source = _copy_download(url, Path(temp_dir))
+            destination = version_dir / source.name
+            result = lastools.runner.run("{exe} -i '{source}' -keep_xy {minx} {miny} {maxx} {maxy} -o '{output}'", exe_name="las2las", kwargs={"source": source, "minx": minx, "miny": miny, "maxx": maxx, "maxy": maxy, "output": destination})
+            if not result.success or not destination.is_file() or destination.stat().st_size == 0:
+                raise RuntimeError(f"las2las failed for AHN{version} tile {tile_id}: {result.stderr}")
     return target
 
 
-@asset(
-    group_name="integration_data",
-    ins={"tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"]))},
-    automation_condition=AutomationCondition.eager(),
-)
-def integration_ahn3(
-    config: IntegrationDataConfig,
-    integration_data_store: FileStoreResource,
-    tile_index_ahn,
-) -> Path:
-    return _download_ahn_tiles(
-        tile_index_ahn,
-        (3,),
-        integration_data_store.path / "pointclouds",
-        config.geofilter,
-    )
+@asset(group_name="integration_data", ins={"tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"]))}, automation_condition=AutomationCondition.eager())
+def integration_ahn3(config: IntegrationDataConfig, integration_data_store: FileStoreResource, tile_index_ahn, lastools: LASToolsResource) -> Path:
+    return _download_ahn_tiles(tile_index_ahn, 3, integration_data_store.path / "pointclouds", config.geofilter, lastools)
 
 
-@asset(
-    group_name="integration_data",
-    ins={"tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"]))},
-    automation_condition=AutomationCondition.eager(),
-)
-def integration_ahn4(
-    config: IntegrationDataConfig,
-    integration_data_store: FileStoreResource,
-    tile_index_ahn,
-) -> Path:
-    return _download_ahn_tiles(
-        tile_index_ahn,
-        (4,),
-        integration_data_store.path / "pointclouds",
-        config.geofilter,
-    )
+@asset(group_name="integration_data", ins={"tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"]))}, automation_condition=AutomationCondition.eager())
+def integration_ahn4(config: IntegrationDataConfig, integration_data_store: FileStoreResource, tile_index_ahn, lastools: LASToolsResource) -> Path:
+    return _download_ahn_tiles(tile_index_ahn, 4, integration_data_store.path / "pointclouds", config.geofilter, lastools)
 
 
-@asset(
-    group_name="integration_data",
-    ins={"tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"]))},
-    automation_condition=AutomationCondition.eager(),
-)
-def integration_ahn5(
-    config: IntegrationDataConfig,
-    integration_data_store: FileStoreResource,
-    tile_index_ahn,
-) -> Path:
-    return _download_ahn_tiles(
-        tile_index_ahn,
-        (5,),
-        integration_data_store.path / "pointclouds",
-        config.geofilter,
-    )
+@asset(group_name="integration_data", ins={"tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"]))}, automation_condition=AutomationCondition.eager())
+def integration_ahn5(config: IntegrationDataConfig, integration_data_store: FileStoreResource, tile_index_ahn, lastools: LASToolsResource) -> Path:
+    return _download_ahn_tiles(tile_index_ahn, 5, integration_data_store.path / "pointclouds", config.geofilter, lastools)
 
 
-@asset(
-    group_name="integration_data",
-    ins={"tile_index_ahn6": AssetIn(key=AssetKey(["ahn", "tile_index_ahn6"]))},
-    automation_condition=AutomationCondition.eager(),
-)
-def integration_ahn6(
-    config: IntegrationDataConfig,
-    integration_data_store: FileStoreResource,
-    tile_index_ahn6,
-) -> Path:
-    return _download_ahn_tiles(
-        tile_index_ahn6,
-        (6,),
-        integration_data_store.path / "pointclouds",
-        config.geofilter,
-        config.ahn6_allowlist,
-    )
+@asset(group_name="integration_data", ins={"tile_index_ahn6": AssetIn(key=AssetKey(["ahn", "tile_index_ahn6"]))}, automation_condition=AutomationCondition.eager())
+def integration_ahn6(config: IntegrationDataConfig, integration_data_store: FileStoreResource, tile_index_ahn6, lastools: LASToolsResource) -> Path:
+    return _download_ahn_tiles(tile_index_ahn6, 6, integration_data_store.path / "pointclouds", config.geofilter, lastools, config.ahn6_allowlist)
 
 
-@asset(
-    group_name="integration_data",
-    automation_condition=AutomationCondition.eager(),
-    ins={
-        "extract_bag": AssetIn(key=AssetKey(["bag", "extract_bag"])),
-        "extract_bgt": AssetIn(key=AssetKey(["bgt", "extract_bgt"])),
-        "extract_top10nl": AssetIn(key=AssetKey(["top10nl", "extract_top10nl"])),
-        "extract_cbs_key_figures": AssetIn(
-            key=AssetKey(["cbs", "extract_cbs_key_figures"])
-        ),
-        "extract_cbs_buurtkaart": AssetIn(
-            key=AssetKey(["cbs", "extract_cbs_buurtkaart"])
-        ),
-        "tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"])),
-        "tile_index_ahn6": AssetIn(key=AssetKey(["ahn", "tile_index_ahn6"])),
-        "md5_ahn3": AssetIn(key=AssetKey(["ahn", "md5_ahn3"])),
-        "md5_ahn4": AssetIn(key=AssetKey(["ahn", "md5_ahn4"])),
-        "sha256_ahn5": AssetIn(key=AssetKey(["ahn", "sha256_ahn5"])),
-        "sha256_ahn6": AssetIn(key=AssetKey(["ahn", "sha256_ahn6"])),
-    },
-)
-def integration_manifest(
-    integration_data_store: FileStoreResource,
-    integration_bag,
-    integration_bgt,
-    integration_top10nl,
-    integration_cbs_key_figures,
-    integration_cbs_buurtkaart,
-    integration_ahn3,
-    integration_ahn4,
-    integration_ahn5,
-    integration_ahn6,
-    extract_bag,
-    extract_bgt,
-    extract_top10nl,
-    extract_cbs_key_figures,
-    extract_cbs_buurtkaart,
-    tile_index_ahn,
-    tile_index_ahn6,
-    md5_ahn3,
-    md5_ahn4,
-    sha256_ahn5,
-    sha256_ahn6,
-) -> Path:
-    """Write the complete, versioned snapshot manifest used by fixture mode."""
+@asset(group_name="integration_data", automation_condition=AutomationCondition.eager(), ins={"extract_bag": AssetIn(key=AssetKey(["bag", "extract_bag"])), "extract_bgt": AssetIn(key=AssetKey(["bgt", "extract_bgt"])), "extract_top10nl": AssetIn(key=AssetKey(["top10nl", "extract_top10nl"])), "extract_cbs_key_figures": AssetIn(key=AssetKey(["cbs", "extract_cbs_key_figures"])), "extract_cbs_buurtkaart": AssetIn(key=AssetKey(["cbs", "extract_cbs_buurtkaart"])), "tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"])), "tile_index_ahn6": AssetIn(key=AssetKey(["ahn", "tile_index_ahn6"])), "md5_ahn3": AssetIn(key=AssetKey(["ahn", "md5_ahn3"])), "md5_ahn4": AssetIn(key=AssetKey(["ahn", "md5_ahn4"])), "sha256_ahn5": AssetIn(key=AssetKey(["ahn", "sha256_ahn5"])), "sha256_ahn6": AssetIn(key=AssetKey(["ahn", "sha256_ahn6"]))})
+def integration_manifest(integration_data_store: FileStoreResource, integration_bag, integration_bgt, integration_top10nl, integration_cbs_key_figures, integration_cbs_buurtkaart, integration_ahn3, integration_ahn4, integration_ahn5, integration_ahn6, extract_bag, extract_bgt, extract_top10nl, extract_cbs_key_figures, extract_cbs_buurtkaart, tile_index_ahn, tile_index_ahn6, md5_ahn3, md5_ahn4, sha256_ahn5, sha256_ahn6) -> Path:
     root = integration_data_store.path
-    files = {}
-    for path in sorted(
-        p for p in root.rglob("*") if p.is_file() and p.name != "manifest.json"
-    ):
-        relative = str(path.relative_to(root))
-        files[relative] = {"size": path.stat().st_size}
-
-    def rel(path):
-        return str(Path(path).relative_to(root))
-
-    bag_dir = Path(integration_bag)
-    if not bag_dir.is_absolute():
-        bag_dir = root / bag_dir
+    files: dict[str, dict[str, Any]] = {}
+    for path in sorted(path for path in root.rglob("*") if path.is_file() and path.name != "manifest.json"):
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        files[str(path.relative_to(root))] = {"size": path.stat().st_size, "sha256": digest}
+    def rel(path: Path | str) -> str:
+        return str(Path(path).resolve().relative_to(root.resolve()))
     bag_value = extract_bag if isinstance(extract_bag, tuple) else (extract_bag, {}, "")
-    sources = {
-        "bag": {
-            "path": rel(bag_dir),
-            "metadata": bag_value[1],
-            "shortdate": bag_value[2],
-        },
-        "bgt": {"path": rel(integration_bgt)},
-        "top10nl": {"path": rel(integration_top10nl)},
-        "cbs_key_figures": {"path": rel(integration_cbs_key_figures)},
-        "cbs_buurtkaart": {"path": rel(integration_cbs_buurtkaart)},
-    }
-    indexes = {"3": tile_index_ahn, "6": tile_index_ahn6}
-    checksums = {"3": md5_ahn3, "4": md5_ahn4, "5": sha256_ahn5, "6": sha256_ahn6}
-    partitions = {}
-    for version in (3, 4, 5):
+    sources = {"bag": {"path": rel(integration_bag), "metadata": bag_value[1], "shortdate": bag_value[2]}, "bgt": {"path": rel(integration_bgt)}, "top10nl": {"path": rel(integration_top10nl)}, "cbs_key_figures": {"path": rel(integration_cbs_key_figures)}, "cbs_buurtkaart": {"path": rel(integration_cbs_buurtkaart)}}
+    partitions: dict[str, Any] = {}
+    for version, index in ((3, tile_index_ahn), (4, tile_index_ahn), (5, tile_index_ahn)):
         version_dir = root / "pointclouds" / f"AHN{version}"
-        partitions[str(version)] = {}
-        for tile_id, entry in tile_index_ahn.items():
-            url = entry.get(f"AHN{version}_LAZ")
-            if url and (version_dir / Path(url).name).is_file():
-                partitions[str(version)][tile_id] = {
-                    "path": rel(version_dir / Path(url).name),
-                    "url": url,
-                }
+        partitions[str(version)] = {tile_id: {"path": rel(version_dir / Path(entry[f"AHN{version}_LAZ"]).name), "url": entry[f"AHN{version}_LAZ"], "size": (version_dir / Path(entry[f"AHN{version}_LAZ"]).name).stat().st_size, "sha256": hashlib.sha256((version_dir / Path(entry[f"AHN{version}_LAZ"]).name).read_bytes()).hexdigest()} for tile_id, entry in index.items() if entry.get(f"AHN{version}_LAZ") and (version_dir / Path(entry[f"AHN{version}_LAZ"]).name).is_file()}
     partitions["6"] = {}
     for tile_id, entry in tile_index_ahn6.items():
-        url = entry.get("url")
-        if url and (root / "pointclouds" / "AHN6" / Path(url).name).is_file():
-            batch = f"{int(tile_id.split('_')[0]) // 10000 * 10000:06d}_{int(tile_id.split('_')[1]) // 10000 * 10000:06d}"
-            partitions["6"].setdefault(batch, {})[tile_id] = {
-                "path": rel(root / "pointclouds" / "AHN6" / Path(url).name),
-                "url": url,
-            }
-    manifest = {
-        "fixture_version": "1",
-        "date": date.today().isoformat(),
-        "sources": sources,
-        "ahn": {"indexes": indexes, "checksums": checksums, "partitions": partitions},
-        "files": files,
-    }
+        if not entry.get("url"):
+            continue
+        path = root / "pointclouds" / "AHN6" / Path(entry["url"]).name
+        if path.is_file():
+            x, y = (int(value) for value in tile_id.split("_"))
+            batch = f"{x // 10000 * 10000:06d}_{y // 10000 * 10000:06d}"
+            partitions["6"].setdefault(batch, {})[tile_id] = {"path": rel(path), "url": entry["url"], "size": path.stat().st_size, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+    manifest = {"fixture_version": "2", "date": date.today().isoformat(), "aoi": {"wkt": AOI_WKT, "minx": 121967, "miny": 485750, "maxx": 123354, "maxy": 486550}, "clipping": {"vectors": "gdal", "pointclouds": "las2las_keep_xy"}, "sources": sources, "ahn": {"indexes": {"3": tile_index_ahn, "6": tile_index_ahn6}, "checksums": {"3": md5_ahn3, "4": md5_ahn4, "5": sha256_ahn5, "6": sha256_ahn6}, "partitions": partitions}, "files": files}
     return _write_json(root / "manifest.json", manifest)

--- a/packages/core/src/bag3d/core/assets/integration_data.py
+++ b/packages/core/src/bag3d/core/assets/integration_data.py
@@ -30,7 +30,7 @@ _EXTENT = re.compile(r"Extent(?:\s+[^:]+)?:\s*\(([-+0-9.eE]+),\s*([-+0-9.eE]+)\)
 _LAS_BOUND = re.compile(r"^\s*(min|max) x y z:\s*([-+0-9.eE]+)\s+([-+0-9.eE]+)", re.MULTILINE | re.IGNORECASE)
 _STAND_TAG = re.compile(rb"<(?:[A-Za-z_][\w.-]*:)?stand(?:\s|>)")
 _POS_TAG = re.compile(rb"<(?:[A-Za-z_][\w.-]*:)?pos(?:\s|>)")
-_AOI_COORDINATE = re.compile(rb"(?:^|\s)(?:12[12]\d{3}|123[0-3]\d{2})(?:\.\d+)?\s+(?:485[7-9]\d{2}|486[0-5]\d{2})(?:\.\d+)?(?:\s|$)")
+_AOI_COORDINATE = re.compile(rb"(?:^|\s|>)(?:12[12]\d{3}|123[0-3]\d{2})(?:\.\d+)?\s+(?:485[7-9]\d{2}|486[0-5]\d{2})(?:\.\d+)?(?:\s|$)")
 BUFFER_METRES = 10.0
 
 
@@ -54,7 +54,7 @@ def _aoi_bbox(wkt: str) -> tuple[float, float, float, float]:
 
 
 def _bbox_intersects(a: tuple[float, float, float, float], b: tuple[float, float, float, float]) -> bool:
-    return max(a[0], b[0]) < min(a[2], b[2]) and max(a[1], b[1]) < min(a[3], b[3])
+    return max(a[0], b[0]) <= min(a[2], b[2]) and max(a[1], b[1]) <= min(a[3], b[3])
 
 
 def _geometry_bbox(geometry: Mapping[str, Any]) -> tuple[float, float, float, float]:
@@ -116,9 +116,9 @@ def _filter_bag_xml(data: bytes, aoi: tuple[float, float, float, float]) -> byte
     for stand in stands:
         coordinates: list[tuple[float, float]] = []
         valid_geometry = True
-        for pos_list in stand.iter("{*}posList"):
-            values = [float(value) for value in _NUMBER.findall(pos_list.text or "")]
-            dimension_value = pos_list.get("srsDimension")
+        for position in stand.iter("{*}posList", "{*}pos"):
+            values = [float(value) for value in _NUMBER.findall(position.text or "")]
+            dimension_value = position.get("srsDimension")
             if dimension_value is None:
                 dimension = 3 if len(values) % 3 == 0 else 2
             else:
@@ -258,7 +258,7 @@ def integration_top10nl(config: IntegrationDataConfig, integration_data_store: F
 @asset(group_name="integration_data", ins={"extract_cbs_key_figures": AssetIn(key=AssetKey(["cbs", "extract_cbs_key_figures"])), "clipped_buurtkaart": AssetIn(key=AssetKey(["integration_cbs_buurtkaart"]))}, automation_condition=AutomationCondition.eager())
 def integration_cbs_key_figures(config: IntegrationDataConfig, integration_data_store: FileStoreResource, extract_cbs_key_figures, clipped_buurtkaart) -> Path:
     codes = _codes_from_clipped_buurtkaart(Path(clipped_buurtkaart))
-    records = [record for record in extract_cbs_key_figures if any(str(record.get(key, "")).strip() in codes for key in ("Codering", "Code", "code", "BU_CODE", "RegioS"))]
+    records = [record for record in extract_cbs_key_figures if any(str(record.get(key, "")).strip() in codes for key in ("WijkenEnBuurten", "Codering", "Code", "code", "BU_CODE", "RegioS"))]
     return _write_json(integration_data_store.path / "cbs" / "key_figures.json", records)
 
 

--- a/packages/core/src/bag3d/core/assets/integration_data.py
+++ b/packages/core/src/bag3d/core/assets/integration_data.py
@@ -266,7 +266,7 @@ def integration_cbs_buurtkaart(
     target = integration_data_store.path / "cbs" / "buurtkaart.gpkg"
     target.parent.mkdir(parents=True, exist_ok=True)
     result = gdal.runner.run(
-        "{exe} -f GPKG -clipsrc '{aoi}' '{local_path}' '{output}'",
+        "{exe} -f GPKG -clipsrc '{aoi}' '{output}' '{local_path}'",
         exe_name="ogr2ogr",
         kwargs={"aoi": AOI_WKT, "output": target},
         local_path=Path(extract_cbs_buurtkaart),

--- a/packages/core/src/bag3d/core/assets/integration_data.py
+++ b/packages/core/src/bag3d/core/assets/integration_data.py
@@ -1,0 +1,397 @@
+"""Monthly, small-area source-data fixtures.
+
+The assets in this module deliberately write files instead of loading data into
+PostgreSQL.  The resulting directory is a portable test fixture and its manifest
+is the commit marker for a complete snapshot.
+"""
+
+import json
+import re
+import shutil
+from datetime import date
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from dagster import AssetIn, AssetKey, AutomationCondition, Config, asset
+from pydantic import Field
+
+from bag3d.common.resources.files import FileStoreResource
+from bag3d.common.resources.executables import GDALResource
+from bag3d.common.utils.requests import download_file
+
+AOI_WKT = "POLYGON ((121967 485750, 123354 485750, 123354 486550, 121967 486550, 121967 485750))"
+AHN6_AOI_TILE_ALLOWLIST = [
+    "121000_485000",
+    "121000_486000",
+    "122000_485000",
+    "122000_486000",
+    "123000_485000",
+    "123000_486000",
+]
+_NUMBER = re.compile(r"-?\d+(?:\.\d+)?")
+
+
+class IntegrationDataConfig(Config):
+    """Configuration shared by the fixture assets."""
+
+    geofilter: str = Field(default=AOI_WKT)
+    cbs_year: str = Field(default="2025")
+    ahn6_allowlist: list[str] = Field(
+        default_factory=lambda: AHN6_AOI_TILE_ALLOWLIST.copy()
+    )
+
+
+def _aoi_bbox(wkt: str) -> tuple[float, float, float, float]:
+    values = [float(v) for v in _NUMBER.findall(wkt)]
+    if len(values) < 8:
+        raise ValueError(f"Expected a polygon WKT, got {wkt!r}")
+    points = list(zip(values[0::2], values[1::2]))
+    return (
+        min(x for x, _ in points),
+        min(y for _, y in points),
+        max(x for x, _ in points),
+        max(y for _, y in points),
+    )
+
+
+def _bbox_intersects(
+    a: tuple[float, float, float, float], b: tuple[float, float, float, float]
+) -> bool:
+    """Return true only for positive-area intersection."""
+    return max(a[0], b[0]) < min(a[2], b[2]) and max(a[1], b[1]) < min(a[3], b[3])
+
+
+def _geometry_bbox(geometry: Mapping[str, Any]) -> tuple[float, float, float, float]:
+    coordinates = geometry.get("coordinates", [])
+    values: list[float] = []
+
+    def visit(value: Any) -> None:
+        if isinstance(value, (list, tuple)):
+            if len(value) >= 2 and all(isinstance(v, (int, float)) for v in value[:2]):
+                values.extend((float(value[0]), float(value[1])))
+            else:
+                for child in value:
+                    visit(child)
+
+    visit(coordinates)
+    if len(values) < 2:
+        raise ValueError("Geometry has no coordinates")
+    return min(values[0::2]), min(values[1::2]), max(values[0::2]), max(values[1::2])
+
+
+def overlapping_tile_ids(
+    tile_index: Mapping[str, Mapping[str, Any]],
+    geofilter: str = AOI_WKT,
+    allowlist: Iterable[str] | None = None,
+) -> list[str]:
+    """Select tile IDs whose indexed geometry overlaps the AOI."""
+    aoi = _aoi_bbox(geofilter)
+    allowed = set(allowlist) if allowlist is not None else None
+    selected = []
+    for tile_id, entry in tile_index.items():
+        if allowed is not None and tile_id not in allowed:
+            continue
+        geometry = entry.get("geometry")
+        if geometry and _bbox_intersects(_geometry_bbox(geometry), aoi):
+            selected.append(tile_id)
+    return sorted(selected)
+
+
+def ahn6_tiles_for_aoi(
+    tile_index: Mapping[str, Mapping[str, Any]],
+    geofilter: str = AOI_WKT,
+    allowlist: Iterable[str] = (),
+) -> list[str]:
+    """Select AOI tiles from AHN6, applying the explicit fixture allowlist."""
+    return overlapping_tile_ids(tile_index, geofilter, allowlist)
+
+
+def _xml_bbox(data: bytes) -> tuple[float, float, float, float] | None:
+    values = [float(v) for v in _NUMBER.findall(data.decode("utf-8", errors="ignore"))]
+    if len(values) < 4:
+        return None
+    # BAG geometries use x/y pairs; metadata values can also be present, so use
+    # the complete coordinate envelope only when it is in the RD New range.
+    pairs = list(zip(values[0::2], values[1::2]))
+    pairs = [(x, y) for x, y in pairs if 0 < x < 300000 and 0 < y < 700000]
+    if not pairs:
+        return None
+    return (
+        min(x for x, _ in pairs),
+        min(y for _, y in pairs),
+        max(x for x, _ in pairs),
+        max(y for _, y in pairs),
+    )
+
+
+def filter_bag_extract(
+    source: Path, destination: Path, geofilter: str = AOI_WKT
+) -> Path:
+    """Copy a BAG extract while retaining its nested ZIP/XML layout."""
+    destination.mkdir(parents=True, exist_ok=True)
+    aoi = _aoi_bbox(geofilter)
+    for source_file in source.iterdir():
+        target = destination / source_file.name
+        if source_file.suffix.lower() != ".zip":
+            shutil.copy2(source_file, target)
+            continue
+        with (
+            ZipFile(source_file) as source_zip,
+            ZipFile(target, "w", ZIP_DEFLATED) as target_zip,
+        ):
+            for info in source_zip.infolist():
+                data = source_zip.read(info)
+                if info.filename.lower().endswith((".xml", ".gml")):
+                    bbox = _xml_bbox(data)
+                    if bbox is not None and not _bbox_intersects(bbox, aoi):
+                        continue
+                target_zip.writestr(info, data)
+    return destination
+
+
+def matching_cbs_codes(
+    records: Iterable[Mapping[str, Any]],
+    geometries: Mapping[str, Mapping[str, Any]],
+    geofilter: str = AOI_WKT,
+) -> list[dict[str, Any]]:
+    """Keep key figures for intersecting gemeente, wijk, and buurt codes."""
+    aoi = _aoi_bbox(geofilter)
+    codes = {
+        code
+        for code, feature in geometries.items()
+        if feature.get("geometry")
+        and _bbox_intersects(_geometry_bbox(feature["geometry"]), aoi)
+    }
+    result = []
+    for record in records:
+        code = next(
+            (
+                record.get(key)
+                for key in ("Codering", "Code", "code", "BU_CODE", "RegioS")
+                if record.get(key)
+            ),
+            None,
+        )
+        if code is not None and str(code) in codes:
+            result.append(dict(record))
+    return result
+
+
+def _copy_download(url: str, target_dir: Path) -> Path:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / url.rsplit("/", 1)[-1]
+    download_file(url, target, chunk_size=1024 * 1024)
+    return target
+
+
+def _write_json(path: Path, value: Any) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+@asset(
+    group_name="integration_data",
+    ins={"extract_bag": AssetIn(key=AssetKey(["bag", "extract_bag"]))},
+    automation_condition=AutomationCondition.eager(),
+)
+def integration_bag(
+    config: IntegrationDataConfig,
+    integration_data_store: FileStoreResource,
+    extract_bag,
+) -> Path:
+    source = Path(extract_bag[0] if isinstance(extract_bag, tuple) else extract_bag)
+    return filter_bag_extract(
+        source, integration_data_store.path / "bag", config.geofilter
+    )
+
+
+@asset(
+    group_name="integration_data",
+    ins={"extract_bgt": AssetIn(key=AssetKey(["bgt", "extract_bgt"]))},
+    automation_condition=AutomationCondition.eager(),
+)
+def integration_bgt(integration_data_store: FileStoreResource, extract_bgt) -> Path:
+    target = integration_data_store.path / "bgt" / Path(extract_bgt).name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(extract_bgt, target)
+    return target
+
+
+@asset(
+    group_name="integration_data",
+    ins={"extract_top10nl": AssetIn(key=AssetKey(["top10nl", "extract_top10nl"]))},
+    automation_condition=AutomationCondition.eager(),
+)
+def integration_top10nl(
+    integration_data_store: FileStoreResource, extract_top10nl
+) -> Path:
+    target = integration_data_store.path / "top10nl" / Path(extract_top10nl).name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(extract_top10nl, target)
+    return target
+
+
+@asset(
+    group_name="integration_data",
+    ins={
+        "extract_cbs_key_figures": AssetIn(
+            key=AssetKey(["cbs", "extract_cbs_key_figures"])
+        )
+    },
+    automation_condition=AutomationCondition.eager(),
+)
+def integration_cbs_key_figures(
+    integration_data_store: FileStoreResource, extract_cbs_key_figures
+) -> Path:
+    target = integration_data_store.path / "cbs" / "key_figures.json"
+    return _write_json(target, extract_cbs_key_figures)
+
+
+@asset(
+    group_name="integration_data",
+    ins={
+        "extract_cbs_buurtkaart": AssetIn(
+            key=AssetKey(["cbs", "extract_cbs_buurtkaart"])
+        )
+    },
+    automation_condition=AutomationCondition.eager(),
+)
+def integration_cbs_buurtkaart(
+    integration_data_store: FileStoreResource,
+    extract_cbs_buurtkaart,
+    gdal: GDALResource,
+) -> Path:
+    target = integration_data_store.path / "cbs" / "buurtkaart.gpkg"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    result = gdal.runner.run(
+        "{exe} -f GPKG -clipsrc '{aoi}' '{local_path}' '{output}'",
+        exe_name="ogr2ogr",
+        kwargs={"aoi": AOI_WKT, "output": target},
+        local_path=Path(extract_cbs_buurtkaart),
+    )
+    if not result.success:
+        raise RuntimeError(f"Could not clip buurtkaart: {result.stderr}")
+    return target
+
+
+def _download_ahn_tiles(
+    index: Mapping[str, Mapping[str, Any]],
+    versions: Iterable[int],
+    target: Path,
+    geofilter: str,
+    allowlist: Iterable[str] = (),
+) -> Path:
+    target.mkdir(parents=True, exist_ok=True)
+    for version in versions:
+        selected = overlapping_tile_ids(
+            index, geofilter, allowlist if version == 6 else None
+        )
+        version_dir = target / f"AHN{version}"
+        version_dir.mkdir(exist_ok=True)
+        for tile_id in selected:
+            entry = index[tile_id]
+            url = entry.get("url") if version == 6 else entry.get(f"AHN{version}_LAZ")
+            if url:
+                _copy_download(url, version_dir)
+    return target
+
+
+@asset(
+    group_name="integration_data",
+    ins={"tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"]))},
+    automation_condition=AutomationCondition.eager(),
+)
+def integration_ahn3(
+    config: IntegrationDataConfig,
+    integration_data_store: FileStoreResource,
+    tile_index_ahn,
+) -> Path:
+    return _download_ahn_tiles(
+        tile_index_ahn,
+        (3,),
+        integration_data_store.path / "pointclouds",
+        config.geofilter,
+    )
+
+
+@asset(
+    group_name="integration_data",
+    ins={"tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"]))},
+    automation_condition=AutomationCondition.eager(),
+)
+def integration_ahn4(
+    config: IntegrationDataConfig,
+    integration_data_store: FileStoreResource,
+    tile_index_ahn,
+) -> Path:
+    return _download_ahn_tiles(
+        tile_index_ahn,
+        (4,),
+        integration_data_store.path / "pointclouds",
+        config.geofilter,
+    )
+
+
+@asset(
+    group_name="integration_data",
+    ins={"tile_index_ahn": AssetIn(key=AssetKey(["ahn", "tile_index_ahn"]))},
+    automation_condition=AutomationCondition.eager(),
+)
+def integration_ahn5(
+    config: IntegrationDataConfig,
+    integration_data_store: FileStoreResource,
+    tile_index_ahn,
+) -> Path:
+    return _download_ahn_tiles(
+        tile_index_ahn,
+        (5,),
+        integration_data_store.path / "pointclouds",
+        config.geofilter,
+    )
+
+
+@asset(
+    group_name="integration_data",
+    ins={"tile_index_ahn6": AssetIn(key=AssetKey(["ahn", "tile_index_ahn6"]))},
+    automation_condition=AutomationCondition.eager(),
+)
+def integration_ahn6(
+    config: IntegrationDataConfig,
+    integration_data_store: FileStoreResource,
+    tile_index_ahn6,
+) -> Path:
+    return _download_ahn_tiles(
+        tile_index_ahn6,
+        (6,),
+        integration_data_store.path / "pointclouds",
+        config.geofilter,
+        config.ahn6_allowlist,
+    )
+
+
+@asset(group_name="integration_data", automation_condition=AutomationCondition.eager())
+def integration_manifest(
+    integration_data_store: FileStoreResource,
+    integration_bag,
+    integration_bgt,
+    integration_top10nl,
+    integration_cbs_key_figures,
+    integration_cbs_buurtkaart,
+    integration_ahn3,
+    integration_ahn4,
+    integration_ahn5,
+    integration_ahn6,
+) -> Path:
+    root = integration_data_store.path
+    files = sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and path.name != "manifest.json"
+    )
+    manifest = {
+        "date": date.today().isoformat(),
+        "files": {str(path.relative_to(root)): path.stat().st_size for path in files},
+    }
+    return _write_json(root / "manifest.json", manifest)

--- a/packages/core/src/bag3d/core/code_location.py
+++ b/packages/core/src/bag3d/core/code_location.py
@@ -14,6 +14,7 @@ from bag3d.core.asset_groups import (
     source_assets,
     input_assets,
     reconstruction_assets,
+    integration_data_assets,
 )
 from bag3d.core.jobs import (
     job_bgt,
@@ -27,13 +28,16 @@ from bag3d.core.jobs import (
     job_ahn_metadata_index,
     job_reconstruct,
     job_reconstruct_debug,
+    job_integration_data,
 )
+from bag3d.core.schedules import integration_data_schedule
 
 all_assets = [
     *bgt_assets,
     *source_assets,
     *input_assets,
     *reconstruction_assets,
+    *integration_data_assets,
 ]
 
 all_jobs = [
@@ -48,6 +52,7 @@ all_jobs = [
     job_ahn_metadata_index,
     job_reconstruct,
     job_reconstruct_debug,
+    job_integration_data,
 ]
 
 sensor_status = (
@@ -65,5 +70,9 @@ all_sensors = [
 ]
 
 defs = Definitions(
-    resources=resource_defs, assets=all_assets, jobs=all_jobs, sensors=all_sensors
+    resources=resource_defs,
+    assets=all_assets,
+    jobs=all_jobs,
+    schedules=[integration_data_schedule],
+    sensors=all_sensors,
 )

--- a/packages/core/src/bag3d/core/jobs.py
+++ b/packages/core/src/bag3d/core/jobs.py
@@ -106,3 +106,17 @@ job_reconstruct_debug = define_asset_job(
         ["reconstruction", "reconstructed_building_models"]
     ),
 )
+
+
+job_integration_data = define_asset_job(
+    name="integration_data",
+    description="Refresh the AOI-specific native-format integration-data fixtures.",
+    selection=AssetSelection.groups("integration_data")
+    | AssetSelection.assets(["bag", "extract_bag"])
+    | AssetSelection.assets(["bgt", "extract_bgt"])
+    | AssetSelection.assets(["top10nl", "extract_top10nl"])
+    | AssetSelection.assets(["cbs", "extract_cbs_key_figures"])
+    | AssetSelection.assets(["cbs", "extract_cbs_buurtkaart"])
+    | AssetSelection.assets(["ahn", "tile_index_ahn"])
+    | AssetSelection.assets(["ahn", "tile_index_ahn6"]),
+)

--- a/packages/core/src/bag3d/core/jobs.py
+++ b/packages/core/src/bag3d/core/jobs.py
@@ -118,5 +118,9 @@ job_integration_data = define_asset_job(
     | AssetSelection.assets(["cbs", "extract_cbs_key_figures"])
     | AssetSelection.assets(["cbs", "extract_cbs_buurtkaart"])
     | AssetSelection.assets(["ahn", "tile_index_ahn"])
-    | AssetSelection.assets(["ahn", "tile_index_ahn6"]),
+    | AssetSelection.assets(["ahn", "tile_index_ahn6"])
+    | AssetSelection.assets(["ahn", "md5_ahn3"])
+    | AssetSelection.assets(["ahn", "md5_ahn4"])
+    | AssetSelection.assets(["ahn", "sha256_ahn5"])
+    | AssetSelection.assets(["ahn", "sha256_ahn6"]),
 )

--- a/packages/core/src/bag3d/core/schedules.py
+++ b/packages/core/src/bag3d/core/schedules.py
@@ -1,0 +1,18 @@
+from dagster import DefaultScheduleStatus, ScheduleDefinition
+
+from bag3d.core.assets.integration_data import AOI_WKT
+from bag3d.core.jobs import job_integration_data
+
+integration_data_schedule = ScheduleDefinition(
+    name="integration_data_monthly",
+    job=job_integration_data,
+    cron_schedule="0 2 1 * *",
+    execution_timezone="Europe/Amsterdam",
+    default_status=DefaultScheduleStatus.STOPPED,
+    run_config={
+        "ops": {
+            "bgt__extract_bgt": {"config": {"geofilter": AOI_WKT}},
+            "top10nl__extract_top10nl": {"config": {"geofilter": AOI_WKT}},
+        }
+    },
+)


### PR DESCRIPTION
  Add a reproducible, AOI-scoped integration-data fixture workflow for the canonical pipeline.

  ## Changes

  - Add integration-data assets for BAG, BGT, TOP10NL, CBS, and AHN sources.
  - Add fixture adapters with manifest, checksum, and fixture-version validation.
  - Clip vector data and point clouds to the integration AOI, validating that outputs remain within the AOI plus a 10 m buffer.
  - Add a dedicated `integration_data` resource, job, and stopped monthly schedule.
  - Add `BAG3D_INPUT_MODE=integration_data` to replace downloaded source assets with read-only local fixtures.
  - Add a Docker Compose overlay for mounting integration data read-only.
  - Document the integration-data runner and future native Dagster orchestration.
